### PR TITLE
feat: EDV Docker Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 GO_CMD ?= go
+EDV_REST_PATH=cmd/edv-rest
+
+# Namespace for the agent images
+DOCKER_OUTPUT_NS   ?= edv
+EDV_REST_IMAGE_NAME   ?= edv-rest
+
+# Tool commands (overridable)
+GO_CMD     ?= go
+ALPINE_VER ?= 3.10
+GO_VER ?= 1.13.1
 
 .PHONY: all
 all: checks unit-test
@@ -17,6 +27,19 @@ lint:
 .PHONY: license
 license:
 	@scripts/check_license.sh
+
+.PHONY: edv-rest
+edv-rest:
+	@echo "Building edv-rest"
+	@mkdir -p ./build/bin
+	@cd ${EDV_REST_PATH} && go build -o ../../build/bin/edv-rest main.go
+
+.PHONY: edv-rest-docker
+edv-rest-docker:
+	@echo "Building edv rest docker image"
+	@docker build -f ./images/edv-rest/Dockerfile --no-cache -t $(DOCKER_OUTPUT_NS)/$(EDV_REST_IMAGE_NAME):latest \
+	--build-arg GO_VER=$(GO_VER) \
+	--build-arg ALPINE_VER=$(ALPINE_VER) .
 
 unit-test:
 	@scripts/check_unit.sh

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@
 [![codecov](https://codecov.io/gh/trustbloc/edv/branch/master/graph/badge.svg)](https://codecov.io/gh/trustbloc/edv)
 [![Go Report Card](https://goreportcard.com/badge/github.com/trustbloc/edv)](https://goreportcard.com/report/github.com/trustbloc/edv)
 
-#edv
+# edv
 An implementation of the [Encrypted Data Vault specification](https://digitalbazaar.github.io/encrypted-data-vaults/).

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -30,3 +30,28 @@ jobs:
         displayName: Run unit test
       - script: bash <(curl https://codecov.io/bash)
         displayName: Upload coverage to Codecov
+
+  - job: Publish
+    dependsOn:
+      - Checks
+      - UnitTest
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    pool:
+      vmImage: ubuntu-18.04
+    timeoutInMinutes: 30
+    steps:
+      - template: azp-dependencies.yml
+      - checkout: self
+      - bash: |
+          function logout {
+            docker logout
+          }
+          trap logout EXIT
+          source ci/version_var.sh
+          echo $DOCKER_PASSWORD | docker login docker.pkg.github.com --username $DOCKER_USER --password-stdin
+          make edv-rest-docker
+          docker tag docker.pkg.github.com/trustbloc/edv/edv-rest:latest docker.pkg.github.com/trustbloc/edv/edv-rest:$EDV_REST_TAG
+          docker push docker.pkg.github.com/trustbloc/edv/edv-rest:$EDV_REST_TAG
+        env:
+          DOCKER_USER: $(DOCKER_USER)
+          DOCKER_PASSWORD: $(DOCKER_PASSWORD)

--- a/ci/version_var.sh
+++ b/ci/version_var.sh
@@ -1,0 +1,21 @@
+
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+# Release Parameters
+BASE_VERSION=0.1.1
+IS_RELEASE=false
+
+if [ $IS_RELEASE == false ]
+then
+  EXTRA_VERSION=snapshot-$(git rev-parse --short=7 HEAD)
+  PROJECT_VERSION=$BASE_VERSION-$EXTRA_VERSION
+else
+  PROJECT_VERSION=$BASE_VERSION
+fi
+
+export EDV_REST_TAG=$PROJECT_VERSION

--- a/cmd/edv-rest/go.mod
+++ b/cmd/edv-rest/go.mod
@@ -8,6 +8,7 @@ replace github.com/trustbloc/edv => ../..
 
 require (
 	github.com/gorilla/mux v1.7.3
+	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
 	github.com/trustbloc/edv v0.0.0

--- a/cmd/edv-rest/startcmd/start.go
+++ b/cmd/edv-rest/startcmd/start.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"net/http"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 
@@ -93,6 +95,7 @@ func startEDV(parameters *edvParameters) error {
 		router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())
 	}
 
+	log.Infof("Starting edv rest server on host %s", parameters.hostURL)
 	err = parameters.srv.ListenAndServe(parameters.hostURL, router)
 
 	return err

--- a/images/edv-rest/Dockerfile
+++ b/images/edv-rest/Dockerfile
@@ -1,0 +1,28 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+ARG GO_VER
+ARG ALPINE_VER
+
+FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
+RUN apk add --no-cache \
+	gcc \
+	musl-dev \
+	git \
+	libtool \
+	bash \
+	make;
+ADD . src/github.com/trustbloc/edv
+WORKDIR src/github.com/trustbloc/edv
+ENV EXECUTABLES go git
+
+FROM golang as edv
+RUN make edv-rest
+
+
+FROM alpine:${ALPINE_VER} as base
+COPY --from=edv /go/src/github.com/trustbloc/edv/build/bin/edv-rest /usr/local/bin
+ENTRYPOINT ["edv-rest"]


### PR DESCRIPTION
Closes #14 

A Docker image for an EDV server can now be published.

Added a line of output to indicate the server is running.

Fixed the readme file not rendering correctly.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>