### PR TITLE
fix: Allow URL-encoded slashes in IDs

### DIFF
--- a/cmd/edv-rest/startcmd/start.go
+++ b/cmd/edv-rest/startcmd/start.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package startcmd
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -26,7 +26,7 @@ const (
 	hostURLEnvKey        = "EDV_HOST_URL"
 )
 
-var errMissingHostURL = errors.New("host URL not provided")
+var errMissingHostURL = fmt.Errorf("host URL not provided")
 
 type edvParameters struct {
 	srv     server
@@ -89,6 +89,7 @@ func startEDV(parameters *edvParameters) error {
 
 	handlers := edvService.GetOperations()
 	router := mux.NewRouter()
+	router.UseEncodedPath()
 
 	for _, handler := range handlers {
 		router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())

--- a/cmd/edv-rest/startcmd/start_test.go
+++ b/cmd/edv-rest/startcmd/start_test.go
@@ -47,7 +47,7 @@ func TestStartCmdWithMissingHostArg(t *testing.T) {
 	err := startCmd.Execute()
 
 	require.Equal(t,
-		"Neither host-url (command line flag) nor EDV_HOST_URL (environment variable) have been set.",
+		"neither host-url (command line flag) nor EDV_HOST_URL (environment variable) have been set",
 		err.Error())
 }
 

--- a/pkg/utils/cmd/util.go
+++ b/pkg/utils/cmd/util.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -31,6 +30,5 @@ func GetUserSetVar(cmd *cobra.Command, flagName, envKey string) (string, error) 
 		return value, nil
 	}
 
-	return "", errors.New("Neither " + flagName + " (command line flag) nor " + envKey +
-		" (environment variable) have been set.")
+	return "", fmt.Errorf("neither %s (command line flag) nor %s (environment variable) have been set", flagName, envKey)
 }

--- a/pkg/utils/cmd/util_test.go
+++ b/pkg/utils/cmd/util_test.go
@@ -35,7 +35,8 @@ func TestGetUserSetVar(t *testing.T) {
 	env, err := GetUserSetVar(cmd, hostURLFlagName, hostURLEnvKey)
 	require.Error(t, err)
 	require.Empty(t, env)
-	require.Contains(t, err.Error(), "TEST_HOST_URL (environment variable) have been set.")
+	require.Equal(t, "neither host-url (command line flag) nor TEST_HOST_URL (environment variable) have been set",
+		err.Error())
 
 	hostURL := "localhost:8080"
 	err = os.Setenv(hostURLEnvKey, hostURL)

--- a/test/bdd/features/edv_e2e_api.feature
+++ b/test/bdd/features/edv_e2e_api.feature
@@ -17,7 +17,7 @@ Feature: Using EDV REST API
     Given EDV server has a data vault with id "testvault2"
     Then  Client sends request to create a new document with id "testdocument" in the data vault with id "testvault2" and receives the document location "localhost:8080/encrypted-data-vaults/testvault2/docs/testdocument" in response
 
-  @retrieve_new_document
+  @read_document
   Scenario: Client retrieves a previously stored document
     Given EDV server has a data vault with id "testvault3"
     Given The data vault with id "testvault3" has a document with id "testdocument"

--- a/test/bdd/pkg/edv/edv_steps.go
+++ b/test/bdd/pkg/edv/edv_steps.go
@@ -104,7 +104,7 @@ func (e *Steps) vaultHasDocument(vaultID, docID string) error {
 func (e *Steps) receiveDocument(docID, vaultID, expectedDocumentArgKey string) error {
 	client := edv.New(e.bddContext.EDVHostURL)
 
-	document, err := client.RetrieveDocument(vaultID, docID)
+	document, err := client.ReadDocument(vaultID, docID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
closes #20

Fixed an issue that was preventing URL-encoded slashes from being used in IDs.

Made some adjustments to returned error codes and function names to improve spec compliance.

Did some minor refactoring and formatting.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>