### PR TITLE
docs: 0.1.1 Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,21 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/trustbloc/edv)](https://goreportcard.com/report/github.com/trustbloc/edv)
 
 # edv
-An implementation of the [Encrypted Data Vault specification](https://digitalbazaar.github.io/encrypted-data-vaults/).
+An implementation of the [Encrypted Data Vault 0.1 (26 January 2020) specification](https://digitalbazaar.github.io/encrypted-data-vaults/). This implementation is at a very early stage; be sure to read the [limitations](#limitations) section which outlines which parts of the specification have yet to be implemented.
+
+## Limitations
+The following has not yet been implemented:
+* Encryption
+* Update and delete document endpoints
+* Streams
+* Indexes
+* Service Discovery
+
+## Testing
+- [Build + BDD Tests](docs/test/build.md)
+
+## Contributing
+Thank you for your interest in contributing. Please see our [community contribution guidelines](https://github.com/trustbloc/community/blob/master/CONTRIBUTING.md) for more information.
+
+## License
+Apache License, Version 2.0 (Apache-2.0). See the [LICENSE](LICENSE) file.

--- a/cmd/edv-rest/go.mod
+++ b/cmd/edv-rest/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/edge-core v0.0.0-20200117175518-7997acf8ed7a
+	github.com/trustbloc/edge-core v0.1.1
 	github.com/trustbloc/edv v0.0.0
 )
 

--- a/cmd/edv-rest/go.sum
+++ b/cmd/edv-rest/go.sum
@@ -38,8 +38,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/edge-core v0.0.0-20200117175518-7997acf8ed7a h1:461cXE3gwaUQpVtUX0xZpNLMHHQDOJmiDd3PAps/U08=
-github.com/trustbloc/edge-core v0.0.0-20200117175518-7997acf8ed7a/go.mod h1:aEkFOyP99eRGPLwCN/4XKFe4ZAPmtroMkf49SRirXkU=
+github.com/trustbloc/edge-core v0.1.1 h1:tyD0vOc1byuj1MY7gmMSGT5oe/Xs+gXTfhzm1YDd/4g=
+github.com/trustbloc/edge-core v0.1.1/go.mod h1:aEkFOyP99eRGPLwCN/4XKFe4ZAPmtroMkf49SRirXkU=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/docs/rest/edv_cli.md
+++ b/docs/rest/edv_cli.md
@@ -1,0 +1,29 @@
+# Run the EDV server as a binary
+
+## Build the EDV server
+
+The EDV server can be built from within the `cmd/edv-rest` directory with `go build`.
+
+## Run the EDV server
+
+Start the edv server with `./edv-rest start [flags]`.
+
+## EDV server Parameters
+
+Parameters can be set by command line arguments or environment variables:
+
+```
+Flags:
+  -u, --host-url string   URL to run the edv instance on. Format: HostName:Port.
+
+* Indicates a required parameter. It must be set by either command line argument or environment variable.
+(If both the command line argument and environment variable are set for a parameter, then the command line argument takes precedence)
+```
+
+## Example
+
+```shell
+$ cd cmd/edv-rest
+$ go build
+$ ./edv-rest start --host-url localhost:8080
+```

--- a/docs/rest/edv_docker.md
+++ b/docs/rest/edv_docker.md
@@ -1,0 +1,15 @@
+# Run the EDV server as a docker container
+
+## Build the EDV server
+Build the docker image for `edv-rest` by running the following make target from the project root directory. 
+
+`make edv-rest-docker`
+
+## Run the EDV server
+The above target will build the docker image `docker.pkg.github.com/trustbloc/edv/edv-rest` which can be used to start the EDV server by running the command
+
+```
+ docker run docker.pkg.github.com/trustbloc/edv/edv-rest:latest start [flags]
+```
+
+Details about flags can be found [here](edv_cli.md#edv-server-parameters).

--- a/docs/test/build.md
+++ b/docs/test/build.md
@@ -1,0 +1,25 @@
+# EDV - Build
+
+## Prerequisites (General)
+- Go 1.13
+
+## Prerequisites (for running tests and demos)
+- Go 1.13
+- Docker
+- Docker-Compose
+- Make
+
+## Targets
+```
+# run all the project build targets
+make all
+
+# run license and linter checks
+make checks
+
+# run unit tests
+make unit-test
+
+# run bdd tests
+make bdd-test
+```

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,5 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/edge-core v0.0.0-20200117175518-7997acf8ed7a
+	github.com/trustbloc/edge-core v0.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/edge-core v0.0.0-20200117175518-7997acf8ed7a h1:461cXE3gwaUQpVtUX0xZpNLMHHQDOJmiDd3PAps/U08=
-github.com/trustbloc/edge-core v0.0.0-20200117175518-7997acf8ed7a/go.mod h1:aEkFOyP99eRGPLwCN/4XKFe4ZAPmtroMkf49SRirXkU=
+github.com/trustbloc/edge-core v0.1.1 h1:tyD0vOc1byuj1MY7gmMSGT5oe/Xs+gXTfhzm1YDd/4g=
+github.com/trustbloc/edge-core v0.1.1/go.mod h1:aEkFOyP99eRGPLwCN/4XKFe4ZAPmtroMkf49SRirXkU=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -101,8 +101,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/trustbloc/edge-core v0.0.0-20200117175518-7997acf8ed7a h1:461cXE3gwaUQpVtUX0xZpNLMHHQDOJmiDd3PAps/U08=
-github.com/trustbloc/edge-core v0.0.0-20200117175518-7997acf8ed7a/go.mod h1:aEkFOyP99eRGPLwCN/4XKFe4ZAPmtroMkf49SRirXkU=
+github.com/trustbloc/edge-core v0.1.1 h1:tyD0vOc1byuj1MY7gmMSGT5oe/Xs+gXTfhzm1YDd/4g=
+github.com/trustbloc/edge-core v0.1.1/go.mod h1:aEkFOyP99eRGPLwCN/4XKFe4ZAPmtroMkf49SRirXkU=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=


### PR DESCRIPTION
closes #23

Added documentation for 0.1.1 release

Updated edge-core dependency to 0.1.1

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>