### PR TITLE
refactor: Client now directly returns EncryptedDocument instead of bytes

### DIFF
--- a/test/bdd/pkg/context/context.go
+++ b/test/bdd/pkg/context/context.go
@@ -18,9 +18,9 @@ type BDDContext struct {
 	EDVHostURL string
 	// TODO: Replace with JWE document instead of legacy/authcrypt: https://github.com/trustbloc/edv/issues/41
 	Packer                     *authcrypt.Packer
-	StructuredDocToBeEncrypted operation.StructuredDocument
-	EncryptedDocToStore        operation.EncryptedDocument
-	ReceivedEncryptedDoc       operation.EncryptedDocument
+	StructuredDocToBeEncrypted *operation.StructuredDocument
+	EncryptedDocToStore        *operation.EncryptedDocument
+	ReceivedEncryptedDoc       *operation.EncryptedDocument
 }
 
 // NewBDDContext create new BDDContext


### PR DESCRIPTION
- Also some minor refactoring in the client unit tests.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>