### PR TITLE
fix: Added nsswitch.conf into the docker image

### DIFF
--- a/images/edv-rest/Dockerfile
+++ b/images/edv-rest/Dockerfile
@@ -23,6 +23,14 @@ FROM golang as edv
 RUN make edv-rest
 
 
-FROM alpine:${ALPINE_VER} as base
+FROM alpine:${ALPINE_VER}
+
+# copy compiled edv-rest binary from build container
 COPY --from=edv /go/src/github.com/trustbloc/edv/build/bin/edv-rest /usr/local/bin
+
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+# setting entrypoint to the binary itself
 ENTRYPOINT ["edv-rest"]


### PR DESCRIPTION
Go's netgo implementation currently does not respect hostname overrides defined in /etc/hosts if the /etc/nsswitch.conf does not exists.

Made changes to your Dockerfile to add a standard /etc/nsswitch.conf to fix this issue.