### PR TITLE
feat: Generate EDV compatible ID function

### DIFF
--- a/pkg/edvutils/edvutils.go
+++ b/pkg/edvutils/edvutils.go
@@ -1,0 +1,33 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package edvutils
+
+import (
+	"crypto/rand"
+
+	"github.com/btcsuite/btcutil/base58"
+)
+
+type generateRandomBytesFunc func([]byte) (int, error)
+
+// GenerateEDVCompatibleID generates an EDV compatible ID using a cryptographically secure random number generator.
+func GenerateEDVCompatibleID() (string, error) {
+	return generateEDVCompatibleID(rand.Read)
+}
+
+func generateEDVCompatibleID(generateRandomBytes generateRandomBytesFunc) (string, error) {
+	randomBytes := make([]byte, 16)
+
+	_, err := generateRandomBytes(randomBytes)
+	if err != nil {
+		return "", err
+	}
+
+	base58EncodedUUID := base58.Encode(randomBytes)
+
+	return base58EncodedUUID, nil
+}

--- a/pkg/edvutils/edvutils_test.go
+++ b/pkg/edvutils/edvutils_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package edvutils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GenerateEDVCompatibleID(t *testing.T) {
+	id, err := GenerateEDVCompatibleID()
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+}
+
+func Test_generateEDVCompatibleID_Failure(t *testing.T) {
+	t.Run("Failure while generating random bytes", func(t *testing.T) {
+		id, err := generateEDVCompatibleID(failingGenerateRandomBytesFunc)
+		require.EqualError(t, err, errRandomByteGeneration.Error())
+		require.Empty(t, id)
+	})
+}
+
+var errRandomByteGeneration = errors.New("failingGenerateRandomBytesFunc always fails")
+
+func failingGenerateRandomBytesFunc(_ []byte) (int, error) {
+	return -1, errRandomByteGeneration
+}


### PR DESCRIPTION
Added a function which can be used by other packages to generate an EDV compatible ID.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>