### PR TITLE
fix: CouchDB query missing results

### DIFF
--- a/cmd/edv-rest/go.mod
+++ b/cmd/edv-rest/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.6.1
-	github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c
+	github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf
 	github.com/trustbloc/edv v0.0.0
 )
 

--- a/cmd/edv-rest/go.sum
+++ b/cmd/edv-rest/go.sum
@@ -815,8 +815,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c h1:fADQh6StK1qg5Qy52p0P9wjO/2EZvng1hF3EDW4fgZE=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf h1:D8Q4KRWD64vWd6hgTdGDsWI0s9pEeKbN1eHsr+FVos0=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b
 	github.com/square/go-jose v2.4.1+incompatible
 	github.com/stretchr/testify v1.6.1
-	github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c
+	github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf
 )
 
 replace github.com/kilic/bls12-381 => github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8

--- a/go.sum
+++ b/go.sum
@@ -780,8 +780,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c h1:fADQh6StK1qg5Qy52p0P9wjO/2EZvng1hF3EDW4fgZE=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf h1:D8Q4KRWD64vWd6hgTdGDsWI0s9pEeKbN1eHsr+FVos0=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b
 	github.com/igor-pavlenko/httpsignatures-go v0.0.21
 	github.com/tidwall/gjson v1.6.0
-	github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c
+	github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf
 	github.com/trustbloc/edv v0.0.0-00010101000000-000000000000
 	github.com/trustbloc/hub-auth v0.0.0-20201118211603-7936a8c44a81 // indirect
 	github.com/trustbloc/hub-auth/test/bdd v0.0.0-20201119220108-8df7631c8dd2

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -998,8 +998,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
 github.com/trustbloc/edge-core v0.1.5-0.20200916124536-c32454a16108/go.mod h1:mTU1E/HcKcjmHaPCjBOvHERuryGhh5zgVkRSi4slAHg=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c h1:fADQh6StK1qg5Qy52p0P9wjO/2EZvng1hF3EDW4fgZE=
-github.com/trustbloc/edge-core v0.1.5-0.20201121093852-c37f1dd38d3c/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf h1:D8Q4KRWD64vWd6hgTdGDsWI0s9pEeKbN1eHsr+FVos0=
+github.com/trustbloc/edge-core v0.1.5-0.20201121214029-0646e96dbdcf/go.mod h1:iOoeeW5Jd6/hhEwaK0+lhBstV7yBWzJxckNU21V0+Vg=
 github.com/trustbloc/hub-auth v0.0.0-20201116135852-764f60b8417b h1:zV0pvpiX/mpdTbjcNas4ICVKid6XU2Zqs4V5+Ibu5sM=
 github.com/trustbloc/hub-auth v0.0.0-20201116135852-764f60b8417b/go.mod h1:gDclLmGBmkJr4KYMKR0dOvOIIb0tkldOMsSDWVH9T5Q=
 github.com/trustbloc/hub-auth v0.0.0-20201118211603-7936a8c44a81 h1:4TrbffQnXTjqgTuv34QXWI1pYif42DBihAxO1YK9HV8=


### PR DESCRIPTION
Fixes an issue where encrypted index querying with a CouchDB backend would fail in some cases. The issue is that the CouchDB query call was only returning the first 25 matching documents. By using the updated edge-core implementation, now the remaining matching documents are retrieved via pagination.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>

closes #70