### PR TITLE
feat: Initial batch endpoint extension implementation

### DIFF
--- a/cmd/edv-rest/startcmd/start_test.go
+++ b/cmd/edv-rest/startcmd/start_test.go
@@ -159,8 +159,8 @@ func TestStartCmdValidArgs(t *testing.T) {
 
 		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
 			"--" + authEnableFlagName, "true", "--" + localKMSSecretsDatabaseTypeFlagName, "mem",
-			"--" + extensionsFlagName, returnFullDocumentOnQueryExtensionName + "," + readAllDocumentsExtensionName,
-			"--" + corsEnableFlagName, "true"}
+			"--" + extensionsFlagName, returnFullDocumentOnQueryExtensionName +
+				"," + readAllDocumentsExtensionName + "," + batchExtensionName, "--" + corsEnableFlagName, "true"}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()

--- a/pkg/restapi/messages/messages.go
+++ b/pkg/restapi/messages/messages.go
@@ -85,11 +85,18 @@ Received data: %s`
 
 	// QueryReceiveRequest is used for logging new queries.
 	QueryReceiveRequest = "Received request to query data vault %s."
+	// BatchReceiveRequest is used for logging new batch operation requests.
+	BatchReceiveRequest = "Received request to do a batch operation in data vault %s."
 	// QueryFailReadRequestBody is used when the incoming request body can't be read.
 	// This should not happen during normal operation.
 	QueryFailReadRequestBody = QueryReceiveRequest + " Failed to read the request body: %s."
+	// BatchFailReadRequestBody is used when the incoming request body can't be read.
+	// This should not happen during normal operation.
+	BatchFailReadRequestBody = BatchReceiveRequest + " Failed to read the request body: %s."
 	// InvalidQuery is used when an invalid query is received.
 	InvalidQuery = `Received invalid query for data vault %s: %s.`
+	// InvalidBatch is used when an invalid batch operation is received.
+	InvalidBatch = `Received invalid batch operation for data vault %s: %s.`
 	// QueryFailure is used when an error occurs while querying a vault.
 	QueryFailure = `Failure while querying vault %s: %s.`
 	// QuerySuccess is used when a vault is successfully queried.
@@ -103,6 +110,9 @@ Received data: %s`
 	// MarshalQueryForLogFailure is used when the log level is set to debug and a query
 	// fails to marshal back into bytes for logging purposes.
 	MarshalQueryForLogFailure = "Failed to marshal query back into bytes for logging purposes: %s."
+	// MarshalBatchForLogFailure is used when the log level is set to debug and a batch request
+	// fails to marshal back into bytes for logging purposes.
+	MarshalBatchForLogFailure = "Failed to marshal batch request back into bytes for logging purposes: %s."
 
 	// CreateDocumentReceiveRequest is used for logging create document requests.
 	CreateDocumentReceiveRequest = "Received request to create a new document in data vault %s."
@@ -161,8 +171,8 @@ Received data: %s`
 	// UpdateDocumentFailReadRequestBody is used when the incoming request body can't be read.
 	// This should not happen during normal operation.
 	UpdateDocumentFailReadRequestBody = UpdateDocumentReceiveRequest + ` Failed to read request body: %s.`
-	// UnmatchedDocIDs is used when docIDs obtained from the path variable and the request body are different.
-	UnmatchedDocIDs = "document IDs from the path variable and the request body have to be the same"
+	// MismatchedDocIDs is used when docIDs obtained from the path variable and the request body are different.
+	MismatchedDocIDs = "document IDs from the path variable and the request body have to be the same"
 	// InvalidDocumentForDocUpdate is used when an invalid document is received while updating a document.
 	InvalidDocumentForDocUpdate = `Received a request to update document %s in vault %s, ` +
 		"but the document is invalid: %s."
@@ -180,6 +190,11 @@ Received data: %s`
 	DeleteDocumentFailure = `Failed to delete document %s in vault %s: %s.`
 	// DeleteMappingDocumentFailure is used when an error occurs while deleting a mapping document for the document.
 	DeleteMappingDocumentFailure = "failed to delete mapping document: %s"
+
+	// BatchResponseSuccess is used when all operations within a batch request execute successfully.
+	BatchResponseSuccess = `Successfully performed batch operation. Vault ID: %s, Request: %s, Response: %s`
+	// BatchResponseFailure is used when one or more operations within a batch request fail.
+	BatchResponseFailure = `Failure during batch operation. Vault ID: %s, Request: %s, Response: %s`
 
 	// PutLogSpecFailReadRequestBody is used when the incoming request body can't be read.
 	// This should not happen during normal operation.

--- a/pkg/restapi/models/models.go
+++ b/pkg/restapi/models/models.go
@@ -63,10 +63,28 @@ type IDTypePair struct {
 }
 
 // Query represents a name+value pair that can be used to query the encrypted indices for specific data.
+// ReturnFullDocuments is optional and can only be used if the "ReturnFullDocumentsOnQuery" extension is enabled.
 type Query struct {
 	ReturnFullDocuments bool   `json:"returnFullDocuments"`
 	Name                string `json:"index"`
 	Value               string `json:"equals"`
+}
+
+// Batch represents a batch of operations to be performed in a vault.
+type Batch []VaultOperation
+
+const (
+	// UpsertDocumentVaultOperation represents an upsert operation to be performed in a batch.
+	UpsertDocumentVaultOperation = "upsert"
+	// DeleteDocumentVaultOperation represents a delete operation to be performed in a batch.
+	DeleteDocumentVaultOperation = "delete"
+)
+
+// VaultOperation represents an upsert or delete operation to be performed in a vault.
+type VaultOperation struct {
+	Operation         string            `json:"operation"`          // Valid values: upsert,delete
+	DocumentID        string            `json:"id,omitempty"`       // Only used if Operation=delete
+	EncryptedDocument EncryptedDocument `json:"document,omitempty"` // Only used if Operation=createOrUpdate
 }
 
 // JSONWebEncryption represents a JWE

--- a/pkg/restapi/operation/respond.go
+++ b/pkg/restapi/operation/respond.go
@@ -317,3 +317,22 @@ func writeDeleteDocumentFailure(rw http.ResponseWriter, errDeleteDoc error, docI
 		logger.Errorf(messages.DeleteDocumentFailure+messages.FailWriteResponse, docID, vaultID, errDeleteDoc, errWrite)
 	}
 }
+
+func writeBatchResponse(rw http.ResponseWriter, batchResponseMsg, vaultID string, request []byte, responses []string) {
+	responsesBytes, err := json.Marshal(responses)
+	if err != nil {
+		logger.Errorf(batchResponseMsg+messages.FailWriteResponse, vaultID, request, responsesBytes, err)
+	}
+
+	if batchResponseMsg == messages.BatchResponseSuccess {
+		logger.Debugf(batchResponseMsg, vaultID, request, responsesBytes)
+	} else {
+		rw.WriteHeader(http.StatusBadRequest)
+		logger.Infof(batchResponseMsg, vaultID, request, responsesBytes)
+	}
+
+	_, err = rw.Write(responsesBytes)
+	if err != nil {
+		logger.Errorf(batchResponseMsg+messages.FailWriteResponse, vaultID, request, responsesBytes, err)
+	}
+}

--- a/pkg/restapi/operation/utils.go
+++ b/pkg/restapi/operation/utils.go
@@ -40,11 +40,14 @@ func convertToFullDocumentURLs(documentIDs []string, vaultID, host string) []str
 	fullDocumentURLs := make([]string, len(documentIDs))
 
 	for i, matchingDocumentID := range documentIDs {
-		fullDocumentURLs[i] = host + "/encrypted-data-vaults/" +
-			url.PathEscape(vaultID) + "/documents/" + url.PathEscape(matchingDocumentID)
+		fullDocumentURLs[i] = getFullDocumentURL(matchingDocumentID, vaultID, host)
 	}
 
 	return fullDocumentURLs
+}
+
+func getFullDocumentURL(documentID, vaultID, host string) string {
+	return host + "/encrypted-data-vaults/" + url.PathEscape(vaultID) + "/documents/" + url.PathEscape(documentID)
 }
 
 func debugLogLevelEnabled() bool {


### PR DESCRIPTION
- This adds an implementation of a batch endpoint extension. In this commit, it's very inefficient since it doesn't actually batch calls to the underlying database provider. It will be optimized in another commit.
- Also added more information to the startup log message.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>