### PR TITLE
feat: Query with CouchDB backend performance optimization

### DIFF
--- a/cmd/edv-rest/go.mod
+++ b/cmd/edv-rest/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.6.1
-	github.com/trustbloc/edge-core v0.1.5-0.20201203211818-a61e670a310e
+	github.com/trustbloc/edge-core v0.1.5-0.20201204205054-05009dc0285c
 	github.com/trustbloc/edv v0.0.0
 )
 

--- a/cmd/edv-rest/go.sum
+++ b/cmd/edv-rest/go.sum
@@ -828,8 +828,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/trustbloc/edge-core v0.1.5-0.20201203211818-a61e670a310e h1:+3hxtmtgQ12uP6rEcrts53Pn7PIwMhKg4l/CT4jzG2w=
-github.com/trustbloc/edge-core v0.1.5-0.20201203211818-a61e670a310e/go.mod h1:S5q7nV9bDdDI4bWl5TeMK9aVnMXtI9K3h1y96rJDbyw=
+github.com/trustbloc/edge-core v0.1.5-0.20201204205054-05009dc0285c h1:kwMBLm5PAETaDwB1mg3OaQF2L6ZPok3Wk6DUYbUPFDw=
+github.com/trustbloc/edge-core v0.1.5-0.20201204205054-05009dc0285c/go.mod h1:S5q7nV9bDdDI4bWl5TeMK9aVnMXtI9K3h1y96rJDbyw=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e h1:i+hGa8C1MKGO71j3jIV7e2aKX72/DTrzLjq9R8kc6xk=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/piprate/json-gold v0.3.0
 	github.com/square/go-jose v2.4.1+incompatible
 	github.com/stretchr/testify v1.6.1
-	github.com/trustbloc/edge-core v0.1.5-0.20201203211818-a61e670a310e
+	github.com/trustbloc/edge-core v0.1.5-0.20201204205054-05009dc0285c
 )
 
 replace github.com/kilic/bls12-381 => github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8

--- a/go.sum
+++ b/go.sum
@@ -783,8 +783,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/trustbloc/edge-core v0.1.5-0.20201203211818-a61e670a310e h1:+3hxtmtgQ12uP6rEcrts53Pn7PIwMhKg4l/CT4jzG2w=
-github.com/trustbloc/edge-core v0.1.5-0.20201203211818-a61e670a310e/go.mod h1:S5q7nV9bDdDI4bWl5TeMK9aVnMXtI9K3h1y96rJDbyw=
+github.com/trustbloc/edge-core v0.1.5-0.20201204205054-05009dc0285c h1:kwMBLm5PAETaDwB1mg3OaQF2L6ZPok3Wk6DUYbUPFDw=
+github.com/trustbloc/edge-core v0.1.5-0.20201204205054-05009dc0285c/go.mod h1:S5q7nV9bDdDI4bWl5TeMK9aVnMXtI9K3h1y96rJDbyw=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e h1:i+hGa8C1MKGO71j3jIV7e2aKX72/DTrzLjq9R8kc6xk=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.5-0.20201120141223-c70cf578d36b
 	github.com/igor-pavlenko/httpsignatures-go v0.0.21
 	github.com/tidwall/gjson v1.6.0
-	github.com/trustbloc/edge-core v0.1.5-0.20201203211818-a61e670a310e
+	github.com/trustbloc/edge-core v0.1.5-0.20201204205054-05009dc0285c
 	github.com/trustbloc/edv v0.0.0-00010101000000-000000000000
 	gotest.tools/v3 v3.0.3 // indirect
 )

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -843,8 +843,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8 h1:VtbBrpzy6rg4EHKOgGDOhBlFg8WWb0dFTYGz140gtj4=
 github.com/trustbloc/bls12-381 v0.0.0-20201104214312-31de2a204df8/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/trustbloc/edge-core v0.1.5-0.20201203211818-a61e670a310e h1:+3hxtmtgQ12uP6rEcrts53Pn7PIwMhKg4l/CT4jzG2w=
-github.com/trustbloc/edge-core v0.1.5-0.20201203211818-a61e670a310e/go.mod h1:S5q7nV9bDdDI4bWl5TeMK9aVnMXtI9K3h1y96rJDbyw=
+github.com/trustbloc/edge-core v0.1.5-0.20201204205054-05009dc0285c h1:kwMBLm5PAETaDwB1mg3OaQF2L6ZPok3Wk6DUYbUPFDw=
+github.com/trustbloc/edge-core v0.1.5-0.20201204205054-05009dc0285c/go.mod h1:S5q7nV9bDdDI4bWl5TeMK9aVnMXtI9K3h1y96rJDbyw=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=


### PR DESCRIPTION
Encrypted index querying when using CouchDB is now much faster. Calls to CouchDB that used to be done one at a time are now done in bulk. The performance difference is especially large when there are many documents that share the same encrypted index name tags.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>