### PR TITLE
feat: Batch performance optimization with CouchDB backend

### DIFF
--- a/cmd/edv-rest/startcmd/start_test.go
+++ b/cmd/edv-rest/startcmd/start_test.go
@@ -52,6 +52,10 @@ func (m *mockEDVStore) Put(models.EncryptedDocument) error {
 	return nil
 }
 
+func (m *mockEDVStore) UpsertBulk(documents []models.EncryptedDocument) error {
+	return nil
+}
+
 func (m *mockEDVStore) GetAll() ([][]byte, error) {
 	return nil, nil
 }
@@ -136,8 +140,10 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 	t.Run("test auth enable wrong value", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + authEnableFlagName, "wrong"}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + authEnableFlagName, "wrong",
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -157,10 +163,12 @@ func TestStartCmdValidArgs(t *testing.T) {
 	t.Run("database type: mem", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
 			"--" + authEnableFlagName, "true", "--" + localKMSSecretsDatabaseTypeFlagName, "mem",
 			"--" + extensionsFlagName, returnFullDocumentOnQueryExtensionName +
-				"," + readAllDocumentsExtensionName + "," + batchExtensionName, "--" + corsEnableFlagName, "true"}
+				"," + readAllDocumentsExtensionName + "," + batchExtensionName, "--" + corsEnableFlagName, "true",
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -183,8 +191,10 @@ func TestStartCmdLogLevels(t *testing.T) {
 	t.Run("Log level: critical", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + logLevelFlagName, logLevelCritical}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + logLevelFlagName, logLevelCritical,
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -194,8 +204,10 @@ func TestStartCmdLogLevels(t *testing.T) {
 	t.Run("Log level: error", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + logLevelFlagName, logLevelError}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + logLevelFlagName, logLevelError,
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -205,8 +217,10 @@ func TestStartCmdLogLevels(t *testing.T) {
 	t.Run("Log level: warn", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + logLevelFlagName, logLevelWarn}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + logLevelFlagName, logLevelWarn,
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -216,8 +230,10 @@ func TestStartCmdLogLevels(t *testing.T) {
 	t.Run("Log level: info", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + logLevelFlagName, logLevelInfo}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + logLevelFlagName, logLevelInfo,
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -227,8 +243,10 @@ func TestStartCmdLogLevels(t *testing.T) {
 	t.Run("Log level: debug", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + logLevelFlagName, logLevelDebug}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + logLevelFlagName, logLevelDebug,
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -238,8 +256,10 @@ func TestStartCmdLogLevels(t *testing.T) {
 	t.Run("Invalid log level - default to info", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + logLevelFlagName, "mango"}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + logLevelFlagName, "mango",
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -252,8 +272,10 @@ func TestStartCmdBlankTLSArgs(t *testing.T) {
 	t.Run("Blank cert file arg", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + tlsCertFileFlagName, ""}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + tlsCertFileFlagName, "",
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -262,8 +284,10 @@ func TestStartCmdBlankTLSArgs(t *testing.T) {
 	t.Run("Blank key file arg", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + tlsKeyFileFlagName, ""}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + tlsKeyFileFlagName, "",
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -294,8 +318,10 @@ func TestKeyManager(t *testing.T) {
 	})
 
 	t.Run("Error - CouchDB url is invalid", func(t *testing.T) {
-		parameters := edvParameters{localKMSSecretsStorage: &storageParameters{storageType: databaseTypeCouchDBOption,
-			storageURL: "%"}, databaseTimeout: 1}
+		parameters := edvParameters{localKMSSecretsStorage: &storageParameters{
+			storageType: databaseTypeCouchDBOption,
+			storageURL:  "%",
+		}, databaseTimeout: 1}
 
 		provider, err := createKeyManager(&parameters)
 		require.Error(t, err)
@@ -366,7 +392,8 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 			handlerFunc: func(resourceID string, req *http.Request, w http.ResponseWriter,
 				next http.HandlerFunc) (http.HandlerFunc, error) {
 				return nil, fmt.Errorf("failed to create auth handler")
-			}}}
+			},
+		}}
 
 		responseRecorder := httptest.NewRecorder()
 		h.ServeHTTP(responseRecorder, &http.Request{RequestURI: createVaultPath + "/vaultID"})
@@ -381,7 +408,8 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 				return func(w http.ResponseWriter, r *http.Request) {
 					require.Equal(t, r.RequestURI, createVaultPath+"/vaultID")
 				}, nil
-			}}}
+			},
+		}}
 
 		responseRecorder := httptest.NewRecorder()
 		h.ServeHTTP(responseRecorder, &http.Request{RequestURI: createVaultPath + "/vaultID"})
@@ -462,8 +490,10 @@ func TestGetTimeout(t *testing.T) {
 	t.Run("failure - invalid timeout flag", func(t *testing.T) {
 		startCmd := GetStartCmd(&mockServer{})
 
-		args := []string{"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
-			"--" + databaseTimeoutFlagName, "NotAnInt"}
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080", "--" + databaseTypeFlagName, "mem",
+			"--" + databaseTimeoutFlagName, "NotAnInt",
+		}
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -771,7 +771,7 @@ func TestClient_Batch(t *testing.T) {
 		require.Len(t, responses, len(batch))
 		require.Equal(t, srvAddr+"/encrypted-data-vaults/"+vaultID+"/documents/"+testDocumentID, responses[0])
 		require.Equal(t, srvAddr+"/encrypted-data-vaults/"+vaultID+"/documents/"+testDocumentID2, responses[1])
-		require.Equal(t, "", responses[2])
+		require.Equal(t, srvAddr+"/encrypted-data-vaults/"+vaultID+"/documents/"+testDocumentID, responses[2])
 
 		err = srv.Shutdown(context.Background())
 		require.NoError(t, err)
@@ -825,7 +825,7 @@ func TestClient_Batch(t *testing.T) {
 
 		expectedResponses := []string{
 			"validated but not executed",
-			"invalidOperationName is not a valid vault operation", "not executed",
+			"invalidOperationName is not a valid vault operation", "not validated or executed",
 		}
 
 		expectedResponsesBytes, err := json.Marshal(expectedResponses)

--- a/pkg/edvprovider/couchdbedvprovider/couchdbedvprovider_test.go
+++ b/pkg/edvprovider/couchdbedvprovider/couchdbedvprovider_test.go
@@ -255,8 +255,8 @@ func TestCouchDBEDVStore_Put(t *testing.T) {
 		}
 
 		err := store.Put(testDoc)
-		require.EqualError(t, err, fmt.Errorf("failed to put encrypted document and its associated "+
-			"mapping documents into CouchDB: %w", errTest).Error())
+		require.EqualError(t, err, fmt.Errorf("failed to put encrypted document(s) and their associated "+
+			"mapping document(s) into CouchDB: %w", errTest).Error())
 	})
 }
 
@@ -282,7 +282,7 @@ func storeDocumentsWithEncryptedIndices(t *testing.T,
 	err := store.Put(testDoc1)
 	require.NoError(t, err)
 
-	mappingDoc := couchDBIndexMappingDocument{
+	mappingDoc := indexMappingDocument{
 		IndexName:              "indexName1",
 		MatchingEncryptedDocID: "someID1",
 	}
@@ -932,7 +932,7 @@ func TestCouchDBEDVStore_findDocMatchingQueryEncryptedDocID(t *testing.T) {
 
 		storeOriginalDocumentBeforeUpdate(t, store, &mockCoreStore, testIndexName1, testDocID1, testMappingDocName1)
 
-		mappingDocNamesAndIndexNames, err := store.findDocMatchingQueryEncryptedDocID(testDocID1)
+		mappingDocNamesAndIndexNames, err := store.findDocsMatchingQueryEncryptedDocID(testDocID1)
 		require.NoError(t, err)
 		require.NotEmpty(t, mappingDocNamesAndIndexNames)
 		require.NotEmpty(t, mappingDocNamesAndIndexNames[testMappingDocName1])
@@ -945,7 +945,7 @@ func TestCouchDBEDVStore_findDocMatchingQueryEncryptedDocID(t *testing.T) {
 		}
 		store := CouchDBEDVStore{coreStore: &mockCoreStore, retrievalPageSize: 100}
 
-		mappingDocNamesAndIndexNames, err := store.findDocMatchingQueryEncryptedDocID(testDocID1)
+		mappingDocNamesAndIndexNames, err := store.findDocsMatchingQueryEncryptedDocID(testDocID1)
 		require.Nil(t, mappingDocNamesAndIndexNames)
 		require.NotNil(t, err)
 		require.Error(t, err, testError)
@@ -957,7 +957,7 @@ func TestCouchDBEDVStore_findDocMatchingQueryEncryptedDocID(t *testing.T) {
 		}
 		store := CouchDBEDVStore{coreStore: &mockCoreStore, retrievalPageSize: 100}
 
-		mappingDocNamesAndIndexNames, err := store.findDocMatchingQueryEncryptedDocID(testDocID1)
+		mappingDocNamesAndIndexNames, err := store.findDocsMatchingQueryEncryptedDocID(testDocID1)
 		require.Nil(t, mappingDocNamesAndIndexNames)
 		require.NotNil(t, err)
 		require.Error(t, err, testError)
@@ -980,7 +980,7 @@ func TestCouchDBEDVStore_findDocMatchingQueryEncryptedDocID(t *testing.T) {
 			valueReturn:             marshalledMappingDoc,
 		}
 
-		mappingDocNamesAndIndexNames, err := store.findDocMatchingQueryEncryptedDocID(testDocID1)
+		mappingDocNamesAndIndexNames, err := store.findDocsMatchingQueryEncryptedDocID(testDocID1)
 		require.Nil(t, mappingDocNamesAndIndexNames)
 		require.NotNil(t, err)
 		require.Error(t, err, testError)
@@ -1003,7 +1003,7 @@ func TestCouchDBEDVStore_findDocMatchingQueryEncryptedDocID(t *testing.T) {
 			valueReturn:             marshalledMappingDoc,
 		}
 
-		mappingDocNamesAndIndexNames, err := store.findDocMatchingQueryEncryptedDocID(testDocID1)
+		mappingDocNamesAndIndexNames, err := store.findDocsMatchingQueryEncryptedDocID(testDocID1)
 		require.Nil(t, mappingDocNamesAndIndexNames)
 		require.NotNil(t, err)
 		require.Error(t, err, testError)
@@ -1020,7 +1020,7 @@ func TestCouchDBEDVStore_findDocMatchingQueryEncryptedDocID(t *testing.T) {
 			valueReturn:             []byte("notAMappingDocument"),
 		}
 
-		mappingDocNamesAndIndexNames, err := store.findDocMatchingQueryEncryptedDocID(testDocID1)
+		mappingDocNamesAndIndexNames, err := store.findDocsMatchingQueryEncryptedDocID(testDocID1)
 		require.Nil(t, mappingDocNamesAndIndexNames)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "error unmarshalling rawDoc")
@@ -1043,7 +1043,7 @@ func TestCouchDBEDVStore_findDocMatchingQueryEncryptedDocID(t *testing.T) {
 			valueReturn:             marshalledMappingDoc,
 		}
 
-		mappingDocNamesAndIndexNames, err := store.findDocMatchingQueryEncryptedDocID(testDocID1)
+		mappingDocNamesAndIndexNames, err := store.findDocsMatchingQueryEncryptedDocID(testDocID1)
 		require.Nil(t, mappingDocNamesAndIndexNames)
 		require.NotNil(t, err)
 		require.Error(t, err, testError)
@@ -1156,8 +1156,8 @@ func buildEncryptedDoc(id string, indexedAttributeCol models.IndexedAttributeCol
 	return doc
 }
 
-func buildIndexMappingDocument(indexName, encryptedDocID, mappingDocumentID string) *couchDBIndexMappingDocument {
-	mappingDoc := couchDBIndexMappingDocument{
+func buildIndexMappingDocument(indexName, encryptedDocID, mappingDocumentID string) *indexMappingDocument {
+	mappingDoc := indexMappingDocument{
 		IndexName:              indexName,
 		MatchingEncryptedDocID: encryptedDocID,
 		MappingDocumentName:    mappingDocumentID,

--- a/pkg/edvprovider/edvprovider.go
+++ b/pkg/edvprovider/edvprovider.go
@@ -43,6 +43,9 @@ type EDVStore interface {
 	// Put stores the given document.
 	Put(document models.EncryptedDocument) error
 
+	// UpsertBulk stores the given documents, creating or updating them as needed.
+	UpsertBulk(documents []models.EncryptedDocument) error
+
 	// GetAll fetches all the documents within this store.
 	GetAll() ([][]byte, error)
 

--- a/pkg/edvprovider/memedvprovider/memedvprovider.go
+++ b/pkg/edvprovider/memedvprovider/memedvprovider.go
@@ -67,6 +67,22 @@ func (m MemEDVStore) Put(document models.EncryptedDocument) error {
 	return m.coreStore.Put(document.ID, documentBytes)
 }
 
+// UpsertBulk stores the given documents, creating or updating them as needed.
+func (m MemEDVStore) UpsertBulk(documents []models.EncryptedDocument) error {
+	if documents == nil {
+		return fmt.Errorf("documents array cannot be nil")
+	}
+
+	for _, document := range documents {
+		err := m.Put(document)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // GetAll fetches all the documents within this store.
 func (m MemEDVStore) GetAll() ([][]byte, error) {
 	allKeyValuePairs, err := m.coreStore.GetAll()


### PR DESCRIPTION
Document upserts are now batched together and put in CouchDB in bulk. Batch endpoint is now much faster when using CouchDB.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>