### PR TITLE
chore: Lower TLS min version to 12 in mock login consent

### DIFF
--- a/test/bdd/mock/loginconsent/main.go
+++ b/test/bdd/mock/loginconsent/main.go
@@ -101,7 +101,7 @@ func loadConfig() (*config, error) {
 		serveKeyFile:  serveKeyPath,
 		tlsConfig: &tls.Config{
 			RootCAs:    rootCACerts,
-			MinVersion: tls.VersionTLS13,
+			MinVersion: tls.VersionTLS12,
 		},
 		store: store,
 	}, nil


### PR DESCRIPTION
Signed-off-by: Derek Trider <Derek.Trider@securekey.com>