### PR TITLE
test: Demonstrate load-balancing in BDD-tests

### DIFF
--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 func runBDDTests(tags, format string) int { //nolint: gocognit
 	return godog.RunWithOptions("godogs", func(s *godog.Suite) {
 		var composition []*dockerutil.Composition
-		var composeFiles = []string{"./fixtures/couchdb", "./fixtures/edv-rest"}
+		composeFiles := []string{"./fixtures/couchdb", "./fixtures/edv-rest"}
 		s.BeforeSuite(func() {
 			if os.Getenv("DISABLE_COMPOSITION") != "true" {
 				// Need a unique name, but docker does not allow '-' in names
@@ -62,7 +62,7 @@ func runBDDTests(tags, format string) int { //nolint: gocognit
 				}
 
 				fmt.Println("docker-compose up ... waiting for containers to start ...")
-				testSleep := 50
+				testSleep := 25
 				if os.Getenv("TEST_SLEEP") != "" {
 					var e error
 

--- a/test/bdd/features/edv_e2e_api.feature
+++ b/test/bdd/features/edv_e2e_api.feature
@@ -8,8 +8,7 @@
 @edv_rest
 Feature: Using EDV REST API
 
-  @e2e
-  Scenario: Full end-to-end flow. Create a data vault, store an encrypted document, and then retrieve the encrypted document. Query using an encrypted index. Update an encrypted document, and then retrieve the encrypted document.
+  Scenario: Full end-to-end flow. Create a data vault, store an encrypted document, and then retrieve the encrypted document. Query using an encrypted index. Update an encrypted document and then retrieve the encrypted document.
     Then Client sends request to create a new data vault and receives the vault location
     Then Client constructs a Structured Document with id "VJYHHJx4C8J9Fsgz7rZqSp"
     Then Client encrypts the Structured Document and uses it to construct an Encrypted Document
@@ -24,3 +23,7 @@ Feature: Using EDV REST API
     Then Client decrypts the Encrypted Document it received in order to reconstruct the original Structured Document
     Then Client deletes the Encrypted Document with id "VJYHHJx4C8J9Fsgz7rZqSp" from the vault
     Then Client stores the Encrypted Document again
+
+  Scenario: Creating documents in parallel.
+    Then Client sends request to create a new data vault and receives the vault location
+    Then Client stores 100 documents using 10 threads

--- a/test/bdd/features/healthcheck_api.feature
+++ b/test/bdd/features/healthcheck_api.feature
@@ -13,4 +13,4 @@ Feature: health check
     Then the JSON path "<respKey>" of the response equals "<respKeyVal>"
     Examples:
       | url                                            | respKey       | respKeyVal                                      |
-      | https://localhost:8080/healthcheck              | status        | success                                         |
+      | https://localhost:8076/healthcheck              | status        | success                                         |

--- a/test/bdd/fixtures/edv-rest/.env
+++ b/test/bdd/fixtures/edv-rest/.env
@@ -12,7 +12,8 @@ EDV_REST_IMAGE=ghcr.io/trustbloc/edv
 EDV_REST_IMAGE_TAG=latest
 
 EDV_HOST=0.0.0.0
-EDV_PORT=8080
+EDV_1_PORT=8074
+EDV_2_PORT=8075
 EDV_DATABASE_TYPE=couchdb
 EDV_DATABASE_URL=admin:password@couchdb.example.com:5984
 EDV_DATABASE_PREFIX=edv

--- a/test/bdd/fixtures/edv-rest/docker-compose.yml
+++ b/test/bdd/fixtures/edv-rest/docker-compose.yml
@@ -7,11 +7,25 @@ version: '2'
 
 services:
 
-  edv.example.com:
+  edv.example.com: # load balancer in front of EDV instances
     container_name: edv.example.com
+    image: nginx:latest
+    ports:
+      - 8076:8076
+    volumes:
+      - ../keys/tls:/etc/nginx/certs
+      - ./nginx-config/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - edv-1.example.com
+      - edv-2.example.com
+    networks:
+      - couchdb_bdd_net
+
+  edv-1.example.com:
+    container_name: edv-1.example.com
     image: ${EDV_REST_IMAGE}:${EDV_REST_IMAGE_TAG}
     environment:
-      - EDV_HOST_URL=${EDV_HOST}:${EDV_PORT}
+      - EDV_HOST_URL=${EDV_HOST}:${EDV_1_PORT}
       - EDV_DATABASE_TYPE=${EDV_DATABASE_TYPE}
       - EDV_DATABASE_URL=${EDV_DATABASE_URL}
       - EDV_DATABASE_PREFIX=${EDV_DATABASE_PREFIX}
@@ -23,7 +37,31 @@ services:
       - EDV_LOCALKMS_SECRETS_DATABASE_URL=${EDV_DATABASE_URL}
       - EDV_LOCALKMS_SECRETS_DATABASE_PREFIX=kms
     ports:
-      - ${EDV_PORT}:${EDV_PORT}
+      - ${EDV_1_PORT}:${EDV_1_PORT}
+    volumes:
+      - ../keys/tls:/etc/tls
+    command: start
+    networks:
+      - couchdb_bdd_net
+
+
+  edv-2.example.com:
+    container_name: edv-2.example.com
+    image: ${EDV_REST_IMAGE}:${EDV_REST_IMAGE_TAG}
+    environment:
+      - EDV_HOST_URL=${EDV_HOST}:${EDV_2_PORT}
+      - EDV_DATABASE_TYPE=${EDV_DATABASE_TYPE}
+      - EDV_DATABASE_URL=${EDV_DATABASE_URL}
+      - EDV_DATABASE_PREFIX=${EDV_DATABASE_PREFIX}
+      - EDV_LOG_LEVEL=debug
+      - EDV_TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
+      - EDV_TLS_KEY_FILE=/etc/tls/ec-key.pem
+      - EDV_AUTH_ENABLE=true
+      - EDV_LOCALKMS_SECRETS_DATABASE_TYPE=${EDV_DATABASE_TYPE}
+      - EDV_LOCALKMS_SECRETS_DATABASE_URL=${EDV_DATABASE_URL}
+      - EDV_LOCALKMS_SECRETS_DATABASE_PREFIX=kms
+    ports:
+      - ${EDV_2_PORT}:${EDV_2_PORT}
     volumes:
       - ../keys/tls:/etc/tls
     command: start

--- a/test/bdd/fixtures/edv-rest/nginx-config/nginx.conf
+++ b/test/bdd/fixtures/edv-rest/nginx-config/nginx.conf
@@ -1,0 +1,26 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+events {}
+
+http {
+    upstream edv {
+        server edv-1.example.com:8074;
+        server edv-2.example.com:8075;
+    }
+
+    server {
+        listen 8076 ssl;
+
+        ssl_certificate /etc/nginx/certs/ec-pubCert.pem;
+        ssl_certificate_key /etc/nginx/certs/ec-key.pem;
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        location / {
+            proxy_pass https://edv;
+        }
+    }
+}

--- a/test/bdd/pkg/context/context.go
+++ b/test/bdd/pkg/context/context.go
@@ -121,7 +121,7 @@ const (
     "sequence": 0
 }`
 
-	trustBlocEDVHostURL = "localhost:8080/encrypted-data-vaults"
+	trustBlocEDVHostURL = "localhost:8076/encrypted-data-vaults"
 )
 
 type kmsProvider struct {

--- a/test/bdd/pkg/interop/edv_interop_steps.go
+++ b/test/bdd/pkg/interop/edv_interop_steps.go
@@ -73,7 +73,7 @@ func (e *Steps) trustBlocCreateDataVault() error {
 		return err
 	}
 
-	trustBlocEDVLocationWithTrailingSlash := e.bddInteropContext.TrustBlocEDVHostURL + "/"
+	trustBlocEDVLocationWithTrailingSlash := "edv/encrypted-data-vaults/"
 	if !strings.HasPrefix(trustBlocEDVLocation, trustBlocEDVLocationWithTrailingSlash) {
 		return errors.New("the trustBloc data vault location is " + trustBlocEDVLocation +
 			". It was expected to start with " + trustBlocEDVLocationWithTrailingSlash + " but it didn't")
@@ -149,7 +149,7 @@ func (e *Steps) createDocument() error {
 		return err
 	}
 
-	expectedTrustBlocDocLocation := e.bddInteropContext.TrustBlocEDVHostURL + "/" +
+	expectedTrustBlocDocLocation := "edv/encrypted-data-vaults/" +
 		e.bddInteropContext.TrustBlocEDVDataVaultID + "/documents/" + e.bddInteropContext.SampleDocToStore.ID
 	if trustBlocDocLocation != expectedTrustBlocDocLocation {
 		return common.UnexpectedValueError(expectedTrustBlocDocLocation, trustBlocDocLocation)


### PR DESCRIPTION
- BDD tests now use a load balancer in front of two EDV servers.
- Added a new test that tests parallel document creation.
- Reduced the BDD test delay from 50 to 25 (it was way longer than necessary).

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>