### PR TITLE
refactor: Query terminology, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ An implementation of Encrypted Data Vaults [from the Confidential Storage 0.1 (0
 ## Limitations
 The following has not yet been implemented:
 * Service endpoint discovery
-* Index querying with multiple name+value pairs (which is still a work in-progress in the [specification](https://identity.foundation/confidential-storage/))
+* Encrypted attribute querying with multiple name+value pairs
+* Support for the unique property on an encrypted attribute pair
 * Streams (also a work in-progress in the [specification](https://identity.foundation/confidential-storage/))
 
 ## Underlying Storage

--- a/cmd/edv-rest/startcmd/start.go
+++ b/cmd/edv-rest/startcmd/start.go
@@ -62,7 +62,7 @@ const (
 	databaseTypeEnvKey        = "EDV_DATABASE_TYPE"
 	databaseTypeFlagShorthand = "t"
 	databaseTypeFlagUsage     = "The type of database to use internally in the EDV. " +
-		"Supported options: mem, couchdb, mongodb. Note that mem doesn't support encrypted index querying. " +
+		"Supported options: mem, couchdb, mongodb. " +
 		"Alternatively, this can be set with the following environment variable: " + databaseTypeEnvKey
 
 	databaseTypeMemOption     = "mem"

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,5 +1,5 @@
 # Extensions
-This EDV server implementation includes support for a number of optional features that, as of writing, are not in the specification (but have been requested). They may all be enabled safely without breaking any standard features. Non-extension-aware clients will still work seamlessly.
+This EDV server implementation includes support for a number of optional features that, as of writing, are considered "at-risk" features in the specification and may not be widely supported by other implementations. They may all be enabled safely without breaking any standard features. Non-extension-aware clients will still work seamlessly.
 
 Note that extensions are disabled by default. See [here](rest/edv_cli.md#edv-server-parameters) for information on how to enable extensions.
 
@@ -8,17 +8,13 @@ Allows multiple documents to be created, updated, or deleted in one REST call to
 
 Requests to the endpoint must be in [this format](https://github.com/trustbloc/edv/blob/bf581301a90cc95185354e82a76be717f9e59c77/pkg/restapi/models/models.go#L74). The response body will be an array of responses, one for each vault operation. Responses for successful upserts will be the document locations. No distinction is made between document creation and document updates.
 
-With CouchDB as the storage provider, this endpoint will be significantly faster when you have many documents to be stored at once as compared to calling the standard Create and Update Document endpoints one at a time.
+With MongoDB or CouchDB as the storage provider, this endpoint will be significantly faster when you have many documents to be stored at once as compared to calling the standard Create and Update Document endpoints one at a time.
 
-Note that, as of writing, this endpoint has a few important limitations to be aware of:
-* For new documents, encrypted indices will be created, but no uniqueness validation will occur. Updated documents must have the same encrypted indices (names+values) as the documents they're replacing. No errors will be thrown if either of these limitations are not respected... The underlying database will just get in a bad state. 
-* Delete operations won't benefit much from being batched due to a limitation in the current implementation.
+Note that, as of writing, the implementation has an important limitation to be aware of: batch deletes are not yet optimized. See [#171](https://github.com/trustbloc/edv/issues/171) for more information.
 
 The request in the spec repo to add this feature can be found [here](https://github.com/decentralized-identity/confidential-storage/issues/138).
 
 ## Return Full Documents on Query
-Allows query results to be full documents instead of document locations. This allows clients to directly get their documents in one step instead of requiring them to get the full documents in separate REST calls. Also allows for Get Document batching.
+Allows query results to be full documents instead of document locations. This allows clients to directly get their documents in one step instead of requiring them to get the full documents in separate REST calls.
 
 Queries must include a "returnFullDocuments" field in the JSON set to true for this endpoint to return full documents.
-
-The request in the spec repo to add this feature can be found [here](https://github.com/decentralized-identity/confidential-storage/issues/137).∂

--- a/pkg/edvprovider/edvprovider.go
+++ b/pkg/edvprovider/edvprovider.go
@@ -23,12 +23,6 @@ const logModuleName = "edv-provider"
 
 var logger = log.New(logModuleName)
 
-type indexMappingDocument struct {
-	AttributeName          string `json:"attributeName"`
-	MatchingEncryptedDocID string `json:"matchingEncryptedDocID"`
-	MappingDocumentName    string `json:"mappingDocumentName"`
-}
-
 type (
 	checkIfBase58Encoded128BitValueFunc func(id string) error
 	base58Encoded128BitToUUIDFunc       func(name string) (string, error)
@@ -173,7 +167,7 @@ func (c *Store) Delete(docID string) error {
 	return c.coreStore.Delete(docID)
 }
 
-// Query does an EDV encrypted index query.
+// Query queries for data based on Encrypted Document attributes..
 // If query.Has is not blank, then we assume it's a "has" query, and so any documents with an attribute name matching
 // query.Has will be returned regardless of value.
 // TODO (#168): Add support for pagination (not currently in the spec).

--- a/pkg/restapi/models/models.go
+++ b/pkg/restapi/models/models.go
@@ -96,7 +96,7 @@ const (
 type VaultOperation struct {
 	Operation         string            `json:"operation"`          // Valid values: upsert,delete
 	DocumentID        string            `json:"id,omitempty"`       // Only used if Operation=delete
-	EncryptedDocument EncryptedDocument `json:"document,omitempty"` // Only used if Operation=createOrUpdate
+	EncryptedDocument EncryptedDocument `json:"document,omitempty"` // Only used if Operation=upsert
 }
 
 // JSONWebEncryption represents a JWE

--- a/pkg/restapi/operation/operations.go
+++ b/pkg/restapi/operation/operations.go
@@ -373,13 +373,10 @@ func (c *Operation) deleteDocumentHandler(rw http.ResponseWriter, req *http.Requ
 
 // Response body will be an array of responses, one for each vault operation. Response for a successful upsert
 // will be the document location. No distinction is made between document creation and document updates.
-// TODO (#171): Address the limitations of this endpoint. Specifically...
-//  1. Updated documents must have the same encrypted indices (names+values) as the documents they're replacing,
-//  2. For new documents, encrypted indices will be created, but no uniqueness validation will occur.
-//     (No errors will be thrown if either of these limitations are not respected.
-//     The underlying database will just get in a bad state if you ignore them.)
-//  3. Delete operations are slow because they don't batch with other operations. They force any queued operations
-//     to execute early. Delete operations don't batch with other operations (including other deletes).
+// TODO (#171): Delete operations are slow because they don't batch with other operations. They force any queued
+//  operations to execute early. Delete operations don't batch with other operations (including other deletes).
+//  This limitation was here because of how the storage mechanism for encrypted attributes used to work. We don't need
+//  to do deletes separately anymore.
 func (c *Operation) batchHandler(rw http.ResponseWriter, req *http.Request) {
 	vaultID, success := unescapePathVar(vaultIDPathVariable, mux.Vars(req), rw)
 	if !success {

--- a/pkg/restapi/operation/operations_test.go
+++ b/pkg/restapi/operation/operations_test.go
@@ -85,14 +85,14 @@ const (
   "has": "CUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ"
 }`
 
-	testDocID      = "VJYHHJx4C8J9Fsgz7rZqSp"
-	testDocID2     = "AJYHHJx4C8J9Fsgz7rZqSp"
-	testDocID3     = "CJYHHJx4C8J9Fsgz7rZqSp"
-	mockDocID1     = "docID1"
-	mockDocID2     = "docID2"
-	testIndexName1 = "indexName1"
-	testIndexName2 = "indexName2"
-	testIndexName3 = "indexName3"
+	testDocID               = "VJYHHJx4C8J9Fsgz7rZqSp"
+	testDocID2              = "AJYHHJx4C8J9Fsgz7rZqSp"
+	testDocID3              = "CJYHHJx4C8J9Fsgz7rZqSp"
+	mockDocID1              = "docID1"
+	mockDocID2              = "docID2"
+	encryptedAttributeName1 = "attributeName1"
+	encryptedAttributeName2 = "attributeName2"
+	encryptedAttributeName3 = "attributeName3"
 
 	testJWE1 = `{"protected":"eyJlbmMiOiJDMjBQIn0","recipients":[{"header":{"alg":"A256KW","kid":"https://exam` +
 		`ple.com/kms/z7BgF536GaR"},"encrypted_key":"OR1vdCNvf_B68mfUxFQVT-vyXVrBembuiM40mAAjDC1-Qu5iArDbug"}],` +
@@ -105,10 +105,10 @@ const (
 		`3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD_A","tag":"XFBoMYUZodetZdvTiFvSkQ"}`
 
 	testIndexedAttributeCollections1 = `[{"sequence":0,"hmac":{"id":"","type":""},"attributes":[{"name":"` +
-		testIndexName1 + `","value":"testVal","unique":true},{"name":"` + testIndexName2 +
+		encryptedAttributeName1 + `","value":"testVal","unique":true},{"name":"` + encryptedAttributeName2 +
 		`","value":"testVal","unique":true}]}]`
 	testIndexedAttributeCollections2 = `[{"sequence":0,"hmac":{"id":"","type":""},"attributes":[{"name":"` +
-		testIndexName2 + `","value":"testVal","unique":true},{"name":"` + testIndexName3 +
+		encryptedAttributeName2 + `","value":"testVal","unique":true},{"name":"` + encryptedAttributeName3 +
 		`","value":"testVal","unique":true}]}]`
 
 	testEncryptedDocument = `{"id":"` + testDocID + `","sequence":0,"indexed":null,` +

--- a/test/bdd/features/edv_e2e_api.feature
+++ b/test/bdd/features/edv_e2e_api.feature
@@ -8,14 +8,14 @@
 @edv_rest
 Feature: Using EDV REST API
 
-  Scenario: Full end-to-end flow. Create a data vault, store an encrypted document, and then retrieve the encrypted document. Query using an encrypted index. Update an encrypted document and then retrieve the encrypted document.
+  Scenario: Full end-to-end flow. Create a data vault, store an encrypted document, and then retrieve the encrypted document. Query using an encrypted attribute. Update an encrypted document and then retrieve the encrypted document.
     Then Client sends request to create a new data vault and receives the vault location
     Then Client constructs a Structured Document with id "VJYHHJx4C8J9Fsgz7rZqSp"
     Then Client encrypts the Structured Document and uses it to construct an Encrypted Document
     Then Client stores the Encrypted Document in the data vault
     Then Client sends request to retrieve the previously stored Encrypted Document with id "VJYHHJx4C8J9Fsgz7rZqSp" in the data vault and receives the previously stored Encrypted Document in response
     Then Client decrypts the Encrypted Document it received in order to reconstruct the original Structured Document
-    Then Client queries the vault to find the previously created document with an encrypted index named "CUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ" with associated value "RV58Va4904K-18_L5g_vfARXRWEB00knFSGPpukUBro"
+    Then Client queries the vault to find the previously created document with an encrypted attribute named "CUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ" with associated value "RV58Va4904K-18_L5g_vfARXRWEB00knFSGPpukUBro"
     Then Client changes the Structured Document with id "VJYHHJx4C8J9Fsgz7rZqSp" in order to update the Encrypted Document in the data vault
     Then Client encrypts the new Structured Document and uses it to construct an Encrypted Document
     Then Client updates Structured Document with id "VJYHHJx4C8J9Fsgz7rZqSp" in the data vault

--- a/test/bdd/pkg/edv/edv_steps.go
+++ b/test/bdd/pkg/edv/edv_steps.go
@@ -82,7 +82,7 @@ func (e *Steps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^Client decrypts the Encrypted Document it received`+
 		` in order to reconstruct the original Structured Document$`, e.decryptDocument)
 	s.Step(`^Client queries the vault to find the previously created document `+
-		`with an encrypted index named "([^"]*)" with associated value "([^"]*)"$`,
+		`with an encrypted attribute named "([^"]*)" with associated value "([^"]*)"$`,
 		e.queryVault)
 	s.Step(`^Client changes the Structured Document with id "([^"]*)" in order to update the`+
 		` Encrypted Document in the data vault$`, e.clientReconstructsAStructuredDocument)
@@ -287,8 +287,8 @@ func (e *Steps) decryptDocument() error {
 	return nil
 }
 
-func (e *Steps) queryVault(queryIndexName, queryIndexValue string) error {
-	docURLs, err := e.bddContext.EDVClient.QueryVault(e.bddContext.VaultID, queryIndexName, queryIndexValue)
+func (e *Steps) queryVault(queryAttributeName, queryAttributeValue string) error {
+	docURLs, err := e.bddContext.EDVClient.QueryVault(e.bddContext.VaultID, queryAttributeName, queryAttributeValue)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Updated some of the terminology used for queries to be more accurate. In many instances, the term "index" was being used when really "attribute" was more appropriate. This difference will become important in my next commit when I add an endpoint to create indexes.

- Updated some out-of-date documentation.

- Removed some unneeded code.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>