### PR TITLE
feat: Add index method for EDV client and BDD test

### DIFF
--- a/pkg/edvprovider/edvprovider.go
+++ b/pkg/edvprovider/edvprovider.go
@@ -79,8 +79,8 @@ func (c *Provider) OpenStore(vaultID string) (*Store, error) {
 	return &Store{coreStore: coreStore, name: vaultID, retrievalPageSize: c.retrievalPageSize}, nil
 }
 
-// AddIndexes creates attributes for the given attributeKeys.
-func (c *Provider) AddIndexes(vaultID string, attributeKeys []string) error {
+// AddIndexes creates attributes for the given attributeNames.
+func (c *Provider) AddIndexes(vaultID string, attributeNames []string) error {
 	// Need to make sure the store is open in-memory first before calling GetStoreConfig and SetStoreConfig.
 	_, underlyingStoreName, err := c.openUnderlyingStore(vaultID)
 	if err != nil {
@@ -92,7 +92,7 @@ func (c *Provider) AddIndexes(vaultID string, attributeKeys []string) error {
 		return fmt.Errorf("failed to get existing store configuration: %w", err)
 	}
 
-	storeConfiguration.TagNames = mergeTagNames(storeConfiguration.TagNames, attributeKeys)
+	storeConfiguration.TagNames = mergeTagNames(storeConfiguration.TagNames, attributeNames)
 
 	return c.coreProvider.SetStoreConfig(underlyingStoreName, storeConfiguration)
 }

--- a/pkg/edvprovider/edvprovider_test.go
+++ b/pkg/edvprovider/edvprovider_test.go
@@ -79,8 +79,8 @@ const (
 	testReferenceID = "referenceID"
 	testVaultID     = "9ANbuHxeBcicymvRZfcKB2"
 
-	encryptedAttributeKey1 = "attributeKey1"
-	encryptedAttributeKey2 = "attributeKey2"
+	encryptedAttributeName1 = "attributeName1"
+	encryptedAttributeName2 = "attributeName2"
 )
 
 type mockIterator struct {
@@ -263,7 +263,7 @@ func TestEDVProvider_AddIndexes(t *testing.T) {
 			base58Encoded128BitToUUID:       edvutils.Base58Encoded128BitToUUID,
 		}
 
-		err := prov.AddIndexes(testVaultID, []string{"AttributeKey1", "AttributeKey2"})
+		err := prov.AddIndexes(testVaultID, []string{"AttributeName1", "AttributeName2"})
 		require.NoError(t, err)
 
 		underlyingStoreName, err := prov.getUnderlyingStoreName(testVaultID)
@@ -273,8 +273,8 @@ func TestEDVProvider_AddIndexes(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, storeConfig.TagNames, 2)
-		require.Equal(t, storeConfig.TagNames[0], "AttributeKey1")
-		require.Equal(t, storeConfig.TagNames[1], "AttributeKey2")
+		require.Equal(t, storeConfig.TagNames[0], "AttributeName1")
+		require.Equal(t, storeConfig.TagNames[1], "AttributeName2")
 	})
 	t.Run("Success - add 2 indexes, then add another new one", func(t *testing.T) {
 		prov := Provider{
@@ -283,10 +283,10 @@ func TestEDVProvider_AddIndexes(t *testing.T) {
 			base58Encoded128BitToUUID:       edvutils.Base58Encoded128BitToUUID,
 		}
 
-		err := prov.AddIndexes(testVaultID, []string{"AttributeKey1", "AttributeKey2"})
+		err := prov.AddIndexes(testVaultID, []string{"AttributeName1", "AttributeName2"})
 		require.NoError(t, err)
 
-		err = prov.AddIndexes(testVaultID, []string{"AttributeKey3"})
+		err = prov.AddIndexes(testVaultID, []string{"AttributeName3"})
 		require.NoError(t, err)
 
 		underlyingStoreName, err := prov.getUnderlyingStoreName(testVaultID)
@@ -296,9 +296,9 @@ func TestEDVProvider_AddIndexes(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, storeConfig.TagNames, 3)
-		require.Equal(t, storeConfig.TagNames[0], "AttributeKey1")
-		require.Equal(t, storeConfig.TagNames[1], "AttributeKey2")
-		require.Equal(t, storeConfig.TagNames[2], "AttributeKey3")
+		require.Equal(t, storeConfig.TagNames[0], "AttributeName1")
+		require.Equal(t, storeConfig.TagNames[1], "AttributeName2")
+		require.Equal(t, storeConfig.TagNames[2], "AttributeName3")
 	})
 	t.Run("Success - add 2 indexes, then add two more (but one was already set before)", func(t *testing.T) {
 		prov := Provider{
@@ -307,10 +307,10 @@ func TestEDVProvider_AddIndexes(t *testing.T) {
 			base58Encoded128BitToUUID:       edvutils.Base58Encoded128BitToUUID,
 		}
 
-		err := prov.AddIndexes(testVaultID, []string{"AttributeKey1", "AttributeKey2"})
+		err := prov.AddIndexes(testVaultID, []string{"AttributeName1", "AttributeName2"})
 		require.NoError(t, err)
 
-		err = prov.AddIndexes(testVaultID, []string{"AttributeKey2", "AttributeKey3"})
+		err = prov.AddIndexes(testVaultID, []string{"AttributeName2", "AttributeName3"})
 		require.NoError(t, err)
 
 		underlyingStoreName, err := prov.getUnderlyingStoreName(testVaultID)
@@ -320,9 +320,9 @@ func TestEDVProvider_AddIndexes(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, storeConfig.TagNames, 3)
-		require.Equal(t, storeConfig.TagNames[0], "AttributeKey1")
-		require.Equal(t, storeConfig.TagNames[1], "AttributeKey2")
-		require.Equal(t, storeConfig.TagNames[2], "AttributeKey3")
+		require.Equal(t, storeConfig.TagNames[0], "AttributeName1")
+		require.Equal(t, storeConfig.TagNames[1], "AttributeName2")
+		require.Equal(t, storeConfig.TagNames[2], "AttributeName3")
 	})
 	t.Run("Failed to open underlying store", func(t *testing.T) {
 		prov := Provider{
@@ -331,7 +331,7 @@ func TestEDVProvider_AddIndexes(t *testing.T) {
 			base58Encoded128BitToUUID:       edvutils.Base58Encoded128BitToUUID,
 		}
 
-		err := prov.AddIndexes(testVaultID, []string{"AttributeKey1", "AttributeKey2"})
+		err := prov.AddIndexes(testVaultID, []string{"AttributeName1", "AttributeName2"})
 		require.EqualError(t, err, "failed to open underlying store: open store failure")
 	})
 	t.Run("Failed to get existing store configuration", func(t *testing.T) {
@@ -343,7 +343,7 @@ func TestEDVProvider_AddIndexes(t *testing.T) {
 			base58Encoded128BitToUUID:       edvutils.Base58Encoded128BitToUUID,
 		}
 
-		err := prov.AddIndexes(testVaultID, []string{"AttributeKey1", "AttributeKey2"})
+		err := prov.AddIndexes(testVaultID, []string{"AttributeName1", "AttributeName2"})
 		require.EqualError(t, err, "failed to get existing store configuration: get store config failure")
 	})
 }
@@ -519,8 +519,8 @@ func TestEDVStore_Update(t *testing.T) {
 
 		store := Store{coreStore: memCoreStore, retrievalPageSize: 100}
 
-		documentIndexedAttribute2 := buildIndexedAttribute(encryptedAttributeKey1)
-		documentIndexedAttribute3 := buildIndexedAttribute(encryptedAttributeKey2)
+		documentIndexedAttribute2 := buildIndexedAttribute(encryptedAttributeName1)
+		documentIndexedAttribute3 := buildIndexedAttribute(encryptedAttributeName2)
 		indexedAttributeCollection2 := models.IndexedAttributeCollection{
 			Sequence:          0,
 			HMAC:              models.IDTypePair{},

--- a/pkg/restapi/messages/messages.go
+++ b/pkg/restapi/messages/messages.go
@@ -87,6 +87,8 @@ Received data: %s`
 	QueryReceiveRequest = "Received request to query data vault %s."
 	// BatchReceiveRequest is used for logging new batch operation requests.
 	BatchReceiveRequest = "Received request to do a batch operation in data vault %s."
+	// IndexReceiveRequest is used for logging new batch operation requests.
+	IndexReceiveRequest = "Received request to do an index operation in data vault %s."
 	// QueryFailReadRequestBody is used when the incoming request body can't be read.
 	// This should not happen during normal operation.
 	QueryFailReadRequestBody = QueryReceiveRequest + " Failed to read the request body: %s."

--- a/pkg/restapi/models/models.go
+++ b/pkg/restapi/models/models.go
@@ -131,6 +131,6 @@ type RecipientHeaders struct {
 
 // IndexOperation represents an operation to add, update or remove indexes.
 type IndexOperation struct {
-	Operation     string   `json:"operation"`
-	AttributeKeys []string `json:"attributeKeys"`
+	Operation      string   `json:"operation"`
+	AttributeNames []string `json:"attributeNames"`
 }

--- a/pkg/restapi/operation/operations.go
+++ b/pkg/restapi/operation/operations.go
@@ -279,6 +279,9 @@ func (c *Operation) indexHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	logger.Infof(messages.DebugLogEventWithReceivedData, fmt.Sprintf(messages.IndexReceiveRequest,
+		vaultID), requestBody)
+
 	var indexOperation models.IndexOperation
 
 	err = json.Unmarshal(requestBody, &indexOperation)
@@ -294,7 +297,7 @@ func (c *Operation) indexHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = c.vaultCollection.addIndexes(vaultID, indexOperation.AttributeKeys)
+	err = c.vaultCollection.addIndexes(vaultID, indexOperation.AttributeNames)
 	if err != nil {
 		writeErrorWithVaultIDAndReceivedData(rw, http.StatusBadRequest,
 			messages.FailAddIndexes, err, vaultID, requestBody)
@@ -785,13 +788,13 @@ func (vc *VaultCollection) deleteDocument(docID, vaultID string) error {
 	return store.Delete(docID)
 }
 
-func (vc *VaultCollection) addIndexes(vaultID string, attributeKeys []string) error {
+func (vc *VaultCollection) addIndexes(vaultID string, attributeNames []string) error {
 	err := vc.ensureVaultExists(vaultID)
 	if err != nil {
 		return err
 	}
 
-	err = vc.provider.AddIndexes(vaultID, attributeKeys)
+	err = vc.provider.AddIndexes(vaultID, attributeNames)
 	if err != nil {
 		return err
 	}

--- a/pkg/restapi/operation/operations_test.go
+++ b/pkg/restapi/operation/operations_test.go
@@ -85,14 +85,14 @@ const (
   "has": "CUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ"
 }`
 
-	testDocID              = "VJYHHJx4C8J9Fsgz7rZqSp"
-	testDocID2             = "AJYHHJx4C8J9Fsgz7rZqSp"
-	testDocID3             = "CJYHHJx4C8J9Fsgz7rZqSp"
-	mockDocID1             = "docID1"
-	mockDocID2             = "docID2"
-	encryptedAttributeKey1 = "attributeKey1"
-	encryptedAttributeKey2 = "attributeKey2"
-	encryptedAttributeKey3 = "attributeKey3"
+	testDocID               = "VJYHHJx4C8J9Fsgz7rZqSp"
+	testDocID2              = "AJYHHJx4C8J9Fsgz7rZqSp"
+	testDocID3              = "CJYHHJx4C8J9Fsgz7rZqSp"
+	mockDocID1              = "docID1"
+	mockDocID2              = "docID2"
+	encryptedAttributeName1 = "attributeName1"
+	encryptedAttributeName2 = "attributeName2"
+	encryptedAttributeName3 = "attributeName3"
 
 	testJWE1 = `{"protected":"eyJlbmMiOiJDMjBQIn0","recipients":[{"header":{"alg":"A256KW","kid":"https://exam` +
 		`ple.com/kms/z7BgF536GaR"},"encrypted_key":"OR1vdCNvf_B68mfUxFQVT-vyXVrBembuiM40mAAjDC1-Qu5iArDbug"}],` +
@@ -105,10 +105,10 @@ const (
 		`3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD_A","tag":"XFBoMYUZodetZdvTiFvSkQ"}`
 
 	testIndexedAttributeCollections1 = `[{"sequence":0,"hmac":{"id":"","type":""},"attributes":[{"name":"` +
-		encryptedAttributeKey1 + `","value":"testVal","unique":true},{"name":"` + encryptedAttributeKey2 +
+		encryptedAttributeName1 + `","value":"testVal","unique":true},{"name":"` + encryptedAttributeName2 +
 		`","value":"testVal","unique":true}]}]`
 	testIndexedAttributeCollections2 = `[{"sequence":0,"hmac":{"id":"","type":""},"attributes":[{"name":"` +
-		encryptedAttributeKey2 + `","value":"testVal","unique":true},{"name":"` + encryptedAttributeKey3 +
+		encryptedAttributeName2 + `","value":"testVal","unique":true},{"name":"` + encryptedAttributeName3 +
 		`","value":"testVal","unique":true}]}]`
 
 	testEncryptedDocument = `{"id":"` + testDocID + `","sequence":0,"indexed":null,` +
@@ -1628,7 +1628,7 @@ func TestAddIndex(t *testing.T) {
 
 		vaultID, _ := createDataVaultExpectSuccess(t, op)
 
-		addIndexRequest := `{"operation":"add","attributeKeys":["EUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ"]}`
+		addIndexRequest := `{"operation":"add","attributeNames":["EUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ"]}`
 
 		req, err := http.NewRequest("POST", "",
 			bytes.NewBuffer([]byte(addIndexRequest)))
@@ -1765,7 +1765,7 @@ func TestAddIndex(t *testing.T) {
 			}, 100),
 		})
 
-		addIndexRequest := `{"operation":"add","attributeKeys":["EUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ"]}`
+		addIndexRequest := `{"operation":"add","attributeNames":["EUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ"]}`
 
 		req, err := http.NewRequest("POST", "",
 			bytes.NewBuffer([]byte(addIndexRequest)))

--- a/test/bdd/features/edv_e2e_api.feature
+++ b/test/bdd/features/edv_e2e_api.feature
@@ -15,6 +15,7 @@ Feature: Using EDV REST API
     Then Client stores the Encrypted Document in the data vault
     Then Client sends request to retrieve the previously stored Encrypted Document with id "VJYHHJx4C8J9Fsgz7rZqSp" in the data vault and receives the previously stored Encrypted Document in response
     Then Client decrypts the Encrypted Document it received in order to reconstruct the original Structured Document
+    Then Client creates an index on the "CUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ" attribute name
     Then Client queries the vault to find the previously created document with an encrypted attribute named "CUQaxPtSLtd8L3WBAIkJ4DiVJeqoF6bdnhR7lSaPloZ" with associated value "RV58Va4904K-18_L5g_vfARXRWEB00knFSGPpukUBro"
     Then Client changes the Structured Document with id "VJYHHJx4C8J9Fsgz7rZqSp" in order to update the Encrypted Document in the data vault
     Then Client encrypts the new Structured Document and uses it to construct an Encrypted Document

--- a/test/bdd/pkg/edv/edv_steps.go
+++ b/test/bdd/pkg/edv/edv_steps.go
@@ -81,6 +81,7 @@ func (e *Steps) RegisterSteps(s *godog.Suite) {
 		e.retrieveDocument)
 	s.Step(`^Client decrypts the Encrypted Document it received`+
 		` in order to reconstruct the original Structured Document$`, e.decryptDocument)
+	s.Step(`^Client creates an index on the "([^"]*)" attribute name$`, e.createIndex)
 	s.Step(`^Client queries the vault to find the previously created document `+
 		`with an encrypted attribute named "([^"]*)" with associated value "([^"]*)"$`,
 		e.queryVault)
@@ -287,8 +288,12 @@ func (e *Steps) decryptDocument() error {
 	return nil
 }
 
-func (e *Steps) queryVault(queryAttributeKey, queryAttributeValue string) error {
-	docURLs, err := e.bddContext.EDVClient.QueryVault(e.bddContext.VaultID, queryAttributeKey, queryAttributeValue)
+func (e *Steps) createIndex(attributeName string) error {
+	return e.bddContext.EDVClient.AddIndex(e.bddContext.VaultID, []string{attributeName})
+}
+
+func (e *Steps) queryVault(queryAttributeName, queryAttributeValue string) error {
+	docURLs, err := e.bddContext.EDVClient.QueryVault(e.bddContext.VaultID, queryAttributeName, queryAttributeValue)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Added a method to the EDV client for asking an EDV server to add indexes.

- Added a BDD test step for adding an index using the client.

- Added log message to server when receiving a request to add indexes.

- Changed "attribute key" to "attribute name" to keep in line with current  draft PR in EDV spec for the "add index" endpoint.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>