### PR TITLE
fix: Missing document tags when using update document endpoint

### DIFF
--- a/pkg/edvprovider/edvprovider.go
+++ b/pkg/edvprovider/edvprovider.go
@@ -178,7 +178,7 @@ func (c *Store) Update(newDoc models.EncryptedDocument) error {
 		return err
 	}
 
-	return c.coreStore.Put(newDoc.ID, newDocBytes)
+	return c.coreStore.Put(newDoc.ID, newDocBytes, createTags(newDoc)...)
 }
 
 // Delete deletes the given document.


### PR DESCRIPTION
Signed-off-by: Derek Trider <Derek.Trider@securekey.com>