### PR TITLE
feat: Use one database for all documents instead of one per vault

### DIFF
--- a/cmd/edv-rest/go.mod
+++ b/cmd/edv-rest/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/hyperledger/aries-framework-go v0.1.9-0.20220412155017-81442062e607
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220412202704-113336f6c3d5
-	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220530120019-3080f681b76c
+	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc.1
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220526205258-18d510d84955
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
@@ -48,7 +48,7 @@ require (
 	github.com/ipfs/go-cid v0.0.7 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
 	github.com/kilic/bls12-381 v0.1.1-0.20210503002446-7b7597926c69 // indirect
-	github.com/klauspost/compress v1.15.5 // indirect
+	github.com/klauspost/compress v1.15.6 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
@@ -81,7 +81,7 @@ require (
 	go.mongodb.org/mongo-driver v1.9.1 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
-	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 // indirect
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect

--- a/cmd/edv-rest/go.sum
+++ b/cmd/edv-rest/go.sum
@@ -802,8 +802,8 @@ github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-2
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220412202704-113336f6c3d5 h1:P4n0NOa1w9n3vlPFkohxLTVLL1FEzmNACc6opbjBEq0=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20220412202704-113336f6c3d5/go.mod h1:q8qjsQpYo7AYG0pqQg1zgEoIVc+Hrpf5S0WciiwPDQA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220310013829-55b4443130f8/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220530120019-3080f681b76c h1:0HhZ3pvVu0t+kwnchfTF3mT6BArPgxPR0y3gO1Fmzsk=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220530120019-3080f681b76c/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf h1:F12zbOSRsye3IWK3Zb6prgrqQQFYnz5zjGSCh9pfYzk=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
 github.com/hyperledger/aries-framework-go-ext/component/storage/postgresql v0.0.0-20220411150242-d1c2ed9dc6bb/go.mod h1:35iXtsPH1PImVDq8xFHETtrcvyHhJXKcvf82YJ6/z4k=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc.1 h1:f6yXSwyZ4sCVXelqHmr7+Um1C1vmP7iBrCWDdS57Tgk=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc.1/go.mod h1:iQuNW2ubvFhQQJZLgHbHHUOCI5wDJwm4YlWO8Cukpp8=
@@ -851,8 +851,8 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20220322085443-50e8f9bd208b
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220324201531-18c87667df19/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330133350-1c2d9d65aea4/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330140627-07042d78580c/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955 h1:80KPbv4fo0NBmFV6KCrevQSX9yezkBnz5v5yuEpcrAg=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b h1:wSUDDrB87VuaxOmyb0CmA3wB8vvgZ3p9Te4Dnsi6NXs=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:asiCVCtH/nocWKhZRMz12aFgdUh8lRHqKis0M8Ei/4I=
@@ -997,8 +997,8 @@ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.10.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.5 h1:qyCLMz2JCrKADihKOh9FxnW3houKeNsp2h5OEz0QSEA=
-github.com/klauspost/compress v1.15.5/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.6 h1:6D9PcO8QWu0JyaQ2zUMmu16T1T+zjjEpP91guRsvDfY=
+github.com/klauspost/compress v1.15.6/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -1746,8 +1746,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
-golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/cmd/edv-rest/startcmd/start_test.go
+++ b/cmd/edv-rest/startcmd/start_test.go
@@ -263,7 +263,11 @@ func TestKeyManager(t *testing.T) {
 
 func TestCreateProvider(t *testing.T) {
 	t.Run("Successfully create memory storage provider", func(t *testing.T) {
-		parameters := edvParameters{databaseType: databaseTypeMemOption}
+		parameters := edvParameters{
+			databaseType:         databaseTypeMemOption,
+			configDatabaseName:   defaultConfigDatabaseName,
+			documentDatabaseName: defaultDocumentDatabaseName,
+		}
 
 		provider, err := createEDVProvider(&parameters)
 		require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -8,20 +8,17 @@ go 1.17
 
 require (
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
+	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hyperledger/aries-framework-go v0.1.8
+	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220526205258-18d510d84955
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b
 	github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c
 	github.com/square/go-jose v2.4.1+incompatible
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.8
-)
-
-require (
-	github.com/cenkalti/backoff/v4 v4.1.3
-	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220530120019-3080f681b76c
 	go.mongodb.org/mongo-driver v1.9.1
 )
 
@@ -51,7 +48,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
 	github.com/kilic/bls12-381 v0.1.1-0.20210503002446-7b7597926c69 // indirect
-	github.com/klauspost/compress v1.15.5 // indirect
+	github.com/klauspost/compress v1.15.6 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/minio/sha256-simd v0.1.1 // indirect
@@ -82,7 +79,7 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
-	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 // indirect
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -340,6 +340,8 @@ github.com/hyperledger/aries-framework-go v0.1.8 h1:nKPGTqh+gYWrczJ7mf6clbnDegKP
 github.com/hyperledger/aries-framework-go v0.1.8/go.mod h1:7ilurt17sjWruVIBxZSrwn8qUbROq8LXYYY+O7dNxIM=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220530120019-3080f681b76c h1:0HhZ3pvVu0t+kwnchfTF3mT6BArPgxPR0y3gO1Fmzsk=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220530120019-3080f681b76c/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf h1:F12zbOSRsye3IWK3Zb6prgrqQQFYnz5zjGSCh9pfYzk=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:7D+Y5J9cIsUrMGFAsIED+3bAPNjxp6ggXo0/kT5N6BI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210820175050-dcc7a225178d/go.mod h1:i40JkMHCh9cHHxSc1SYznO3xDH6ly5CE0B3vPYZVeWI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220322085443-50e8f9bd208b/go.mod h1:eIac5lubCy3tw6D0sTluM5U6Bw3inBwUfjX17o2U7PE=
@@ -374,6 +376,8 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20220324201531-18c87667df19
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330140627-07042d78580c/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955 h1:80KPbv4fo0NBmFV6KCrevQSX9yezkBnz5v5yuEpcrAg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b h1:wSUDDrB87VuaxOmyb0CmA3wB8vvgZ3p9Te4Dnsi6NXs=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:asiCVCtH/nocWKhZRMz12aFgdUh8lRHqKis0M8Ei/4I=
@@ -418,6 +422,8 @@ github.com/klauspost/compress v1.10.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.5 h1:qyCLMz2JCrKADihKOh9FxnW3houKeNsp2h5OEz0QSEA=
 github.com/klauspost/compress v1.15.5/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.6 h1:6D9PcO8QWu0JyaQ2zUMmu16T1T+zjjEpP91guRsvDfY=
+github.com/klauspost/compress v1.15.6/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -778,6 +784,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -762,9 +762,11 @@ func getTestValidEncryptedDocument(testJWE string) *models.EncryptedDocument {
 func startEDVServer(t *testing.T, srvAddr string, enabledExtensions *operation.EnabledExtensions) *http.Server {
 	t.Helper()
 
-	memProv := edvprovider.NewProvider(mem.NewProvider(), 100)
+	edvProvider, err := edvprovider.NewProvider(mem.NewProvider(),
+		"configurations", "documents", 100)
+	require.NoError(t, err)
 
-	edvService, err := restapi.New(&operation.Config{Provider: memProv, EnabledExtensions: enabledExtensions})
+	edvService, err := restapi.New(&operation.Config{Provider: edvProvider, EnabledExtensions: enabledExtensions})
 	require.NoError(t, err)
 
 	handlers := edvService.GetOperations()

--- a/pkg/edvprovider/edvprovider.go
+++ b/pkg/edvprovider/edvprovider.go
@@ -15,147 +15,110 @@ import (
 	"github.com/hyperledger/aries-framework-go/spi/storage"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	mongodriver "go.mongodb.org/mongo-driver/mongo"
 	mongooptions "go.mongodb.org/mongo-driver/mongo/options"
 
-	"github.com/trustbloc/edv/pkg/edvutils"
 	"github.com/trustbloc/edv/pkg/restapi/messages"
 	"github.com/trustbloc/edv/pkg/restapi/models"
 )
 
-const logModuleName = "edv-provider"
+const (
+	logModuleName       = "edv-provider"
+	vaultIDTagName      = "vaultID"
+	documentIDFieldName = "id"
+)
 
 var logger = log.New(logModuleName)
-
-type (
-	checkIfBase58Encoded128BitValueFunc func(id string) error
-	base58Encoded128BitToUUIDFunc       func(name string) (string, error)
-)
 
 // Provider represents an EDV storage provider. It's used for performing operations involving creation/instantiation
 // of Vaults.
 // It wraps an Aries storage provider with additional functionality that's needed for EDV operations.
 type Provider struct {
-	CoreProvider                    storage.Provider
-	retrievalPageSize               uint
-	checkIfBase58Encoded128BitValue checkIfBase58Encoded128BitValueFunc
-	base58Encoded128BitToUUID       base58Encoded128BitToUUIDFunc
+	coreProvider      storage.Provider
+	configStore       storage.Store
+	documentsStore    storage.Store
+	retrievalPageSize uint
 }
 
-// NewProvider instantiates a new Provider. retrievalPageSize is used by ariesProvider for query paging.
+// NewProvider instantiates a new EDV storage Provider. retrievalPageSize is used by ariesProvider for query paging.
 // It may be ignored if ariesProvider doesn't support paging.
-func NewProvider(ariesProvider storage.Provider, retrievalPageSize uint) *Provider {
-	return &Provider{
-		CoreProvider:                    ariesProvider,
-		retrievalPageSize:               retrievalPageSize,
-		checkIfBase58Encoded128BitValue: edvutils.CheckIfBase58Encoded128BitValue,
-		base58Encoded128BitToUUID:       edvutils.Base58Encoded128BitToUUID,
+func NewProvider(coreProvider storage.Provider,
+	configDatabaseName, documentDatabaseName string, retrievalPageSize uint) (*Provider, error) {
+	configStore, err := coreProvider.OpenStore(configDatabaseName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open configuration store: %w", err)
 	}
+
+	documentsStore, err := coreProvider.OpenStore(documentDatabaseName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open document store: %w", err)
+	}
+
+	mongoDBProvider, ok := coreProvider.(*mongodb.Provider)
+	if ok {
+		logger.Debugf("Creating indexes for documents database...")
+
+		err = createMongoDBIndex(mongoDBProvider, documentDatabaseName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create indexes in MongoDB: %w", err)
+		}
+
+		logger.Debugf("Successfully created indexes for documents database.")
+	}
+
+	return &Provider{
+		coreProvider:      coreProvider,
+		configStore:       configStore,
+		documentsStore:    documentsStore,
+		retrievalPageSize: retrievalPageSize,
+	}, nil
 }
 
 // CreateNewVault instantiates a new vault with the given dataVaultConfiguration
-func (c *Provider) CreateNewVault(vaultID string, dataVaultConfiguration *models.DataVaultConfiguration) error {
-	store, err := c.OpenVault(vaultID)
-	if err != nil {
-		return fmt.Errorf("failed to open store for vault: %w", err)
-	}
-
-	mongoDBProvider, ok := c.CoreProvider.(*mongodb.Provider)
+func (p *Provider) CreateNewVault(vaultID string, dataVaultConfiguration *models.DataVaultConfiguration) error {
+	mongoDBStore, ok := p.configStore.(*mongodb.Store)
 	if ok {
-		err = createMongoDBAttributeIndex(mongoDBProvider, store.underlyingStoreName)
+		err := mongoDBStore.PutAsJSON(vaultID, dataVaultConfiguration)
 		if err != nil {
-			return err
+			return fmt.Errorf(messages.StoreVaultConfigFailure, err)
 		}
+
+		return nil
 	}
 
-	err = store.StoreDataVaultConfiguration(dataVaultConfiguration)
+	configBytes, err := json.Marshal(dataVaultConfiguration)
 	if err != nil {
-		return fmt.Errorf("failed to store data vault configuration: %w", err)
+		return fmt.Errorf(messages.FailToMarshalConfig, err)
+	}
+
+	err = p.configStore.Put(vaultID, configBytes)
+	if err != nil {
+		return fmt.Errorf(messages.StoreVaultConfigFailure, err)
 	}
 
 	return nil
 }
 
 // VaultExists tells you whether the given vault already exists.
-func (c *Provider) VaultExists(vaultID string) (bool, error) {
-	storeName, err := c.getUnderlyingStoreName(vaultID)
+func (p *Provider) VaultExists(vaultID string) (bool, error) {
+	_, err := p.configStore.Get(vaultID)
 	if err != nil {
-		return false, fmt.Errorf("failed to determine store name to use: %w", err)
-	}
-
-	_, err = c.CoreProvider.GetStoreConfig(storeName)
-	if err != nil {
-		if errors.Is(err, storage.ErrStoreNotFound) {
+		if errors.Is(err, storage.ErrDataNotFound) {
 			return false, nil
 		}
 
-		return false, fmt.Errorf("unexpected error while getting store config: %w", err)
+		return false, fmt.Errorf("unexpected error while checking for vault configuration: %w", err)
 	}
 
 	return true, nil
 }
 
-// OpenVault opens a Vault for the given vaultID and returns it.
-func (c *Provider) OpenVault(vaultID string) (*Vault, error) {
-	coreStore, underlyingStoreName, err := c.openUnderlyingStore(vaultID)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Vault{
-		CoreStore:           coreStore,
-		underlyingStoreName: underlyingStoreName,
-		retrievalPageSize:   c.retrievalPageSize,
-	}, nil
-}
-
-// AddIndexes creates indexes for the given attributeNames.
-func (c *Provider) AddIndexes(vaultID string, attributeNames []string) error {
-	// Need to make sure the store is open in-memory first before calling GetStoreConfig and SetStoreConfig.
-	_, underlyingStoreName, err := c.openUnderlyingStore(vaultID)
-	if err != nil {
-		return fmt.Errorf("failed to open underlying store: %w", err)
-	}
-
-	storeConfiguration, err := c.CoreProvider.GetStoreConfig(underlyingStoreName)
-	if err != nil {
-		return fmt.Errorf("failed to get existing store configuration: %w", err)
-	}
-
-	storeConfiguration.TagNames = mergeTagNames(storeConfiguration.TagNames, attributeNames)
-
-	return c.CoreProvider.SetStoreConfig(underlyingStoreName, storeConfiguration)
-}
-
-func (c *Provider) openUnderlyingStore(vaultID string) (underlyingStore storage.Store,
-	underlyingStoreName string, err error) {
-	storeName, err := c.getUnderlyingStoreName(vaultID)
-	if err != nil {
-		return nil, "",
-			fmt.Errorf("failed to determine underlying store name: %w", err)
-	}
-
-	coreStore, err := c.CoreProvider.OpenStore(storeName)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return coreStore, storeName, nil
-}
-
-// Vault represents a single vault store.
-type Vault struct {
-	CoreStore           storage.Store
-	underlyingStoreName string
-	retrievalPageSize   uint
-}
-
-// Put stores the given documents, creating or updating them as needed.
+// Put stores the given documents into a vault, creating or updating them as needed.
 // TODO (#236): Support "unique" option on attribute pair.
-func (v *Vault) Put(documents ...models.EncryptedDocument) error {
-	mongoDBStore, ok := v.CoreStore.(*mongodb.Store)
+func (p *Provider) Put(vaultID string, documents ...models.EncryptedDocument) error {
+	mongoDBStore, ok := p.documentsStore.(*mongodb.Store)
 	if ok {
-		return storeDocumentsForMongoDB(documents, mongoDBStore)
+		return storeDocumentsForMongoDB(vaultID, documents, mongoDBStore)
 	}
 
 	operations := make([]storage.Operation, len(documents))
@@ -167,12 +130,12 @@ func (v *Vault) Put(documents ...models.EncryptedDocument) error {
 				documents[i].ID, errMarshal)
 		}
 
-		operations[i].Key = documents[i].ID
+		operations[i].Key = generateAriesDocumentEntryKey(vaultID, documents[i].ID)
 		operations[i].Value = documentBytes
-		operations[i].Tags = createTags(documents[i])
+		operations[i].Tags = createTags(vaultID, &documents[i])
 	}
 
-	err := v.CoreStore.Batch(operations)
+	err := p.documentsStore.Batch(operations)
 	if err != nil {
 		return fmt.Errorf("failed to store encrypted document(s): %w", err)
 	}
@@ -180,28 +143,37 @@ func (v *Vault) Put(documents ...models.EncryptedDocument) error {
 	return nil
 }
 
-// Get fetches the document associated with the given id.
-func (v *Vault) Get(id string) ([]byte, error) {
-	mongoDBStore, ok := v.CoreStore.(*mongodb.Store)
+// Get fetches a document from a vault.
+func (p *Provider) Get(vaultID, documentID string) ([]byte, error) {
+	mongoDBStore, ok := p.documentsStore.(*mongodb.Store)
 	if ok {
-		return getFromMongoDB(mongoDBStore, id)
+		return p.getFromMongoDB(mongoDBStore, vaultID, documentID)
 	}
 
-	return v.CoreStore.Get(id)
+	return p.documentsStore.Get(generateAriesDocumentEntryKey(vaultID, documentID))
 }
 
-// Delete deletes the given document.
-func (v *Vault) Delete(docID string) error {
-	return v.CoreStore.Delete(docID)
+// Delete deletes a document from a vault.
+func (p *Provider) Delete(vaultID, documentID string) error {
+	mongoDBStore, ok := p.documentsStore.(*mongodb.Store)
+	if ok {
+		filter := bson.M{documentIDFieldName: documentID, vaultIDTagName: vaultID}
+
+		writeModel := mongodriver.NewDeleteOneModel().SetFilter(filter)
+
+		return mongoDBStore.BulkWrite([]mongodriver.WriteModel{writeModel})
+	}
+
+	return p.documentsStore.Delete(generateAriesDocumentEntryKey(vaultID, documentID))
 }
 
 // Query queries for data based on Encrypted Document attributes.
 // TODO (#168): Add support for pagination (not currently in the spec).
 //  The c.retrievalPageSize parameter is passed in from the startup args and could be used with pagination.
-func (v *Vault) Query(query models.Query) ([]models.EncryptedDocument, error) {
-	mongoDBStore, ok := v.CoreStore.(*mongodb.Store)
+func (p *Provider) Query(vaultID string, query models.Query) ([]models.EncryptedDocument, error) {
+	mongoDBStore, ok := p.documentsStore.(*mongodb.Store)
 	if ok {
-		return v.queryFromMongoDB(mongoDBStore, query)
+		return p.queryFromMongoDB(mongoDBStore, vaultID, query)
 	}
 
 	ariesQuery, err := convertEDVQueryToAriesQuery(query)
@@ -209,7 +181,11 @@ func (v *Vault) Query(query models.Query) ([]models.EncryptedDocument, error) {
 		return nil, err
 	}
 
-	iterator, err := v.CoreStore.Query(ariesQuery, storage.WithPageSize(int(v.retrievalPageSize)))
+	return p.queryForEncryptedDocumentsFromAries(vaultID, ariesQuery)
+}
+
+func (p *Provider) queryForEncryptedDocumentsFromAries(vaultID, ariesQuery string) ([]models.EncryptedDocument, error) {
+	iterator, err := p.documentsStore.Query(ariesQuery, storage.WithPageSize(int(p.retrievalPageSize)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query underlying store: %w", err)
 	}
@@ -224,9 +200,68 @@ func (v *Vault) Query(query models.Query) ([]models.EncryptedDocument, error) {
 	var encryptedDocuments []models.EncryptedDocument
 
 	for moreEntries {
-		encryptedDocumentBytes, valueErr := iterator.Value()
+		isForCorrectVault, err := vaultIDTagMatches(vaultID, iterator)
+		if err != nil {
+			return nil, err
+		}
+
+		if isForCorrectVault {
+			encryptedDocumentBytes, valueErr := iterator.Value()
+			if valueErr != nil {
+				return nil, valueErr
+			}
+
+			var encryptedDocument models.EncryptedDocument
+
+			err = json.Unmarshal(encryptedDocumentBytes, &encryptedDocument)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal encrypted document bytes: %w", err)
+			}
+
+			encryptedDocuments = append(encryptedDocuments, encryptedDocument)
+		}
+
+		moreEntries, err = iterator.Next()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return encryptedDocuments, nil
+}
+
+func (p *Provider) queryFromMongoDB(store *mongodb.Store, vaultID string,
+	query models.Query) ([]models.EncryptedDocument, error) {
+	mongoDBQuery := convertEDVQueryToMongoDBQuery(vaultID, query)
+
+	return p.queryForEncryptedDocumentsFromMongoDB(store, mongoDBQuery)
+}
+
+func (p *Provider) queryForEncryptedDocumentsFromMongoDB(store *mongodb.Store,
+	filter interface{}) ([]models.EncryptedDocument, error) {
+	iterator, err := store.QueryCustom(filter, mongooptions.Find().SetBatchSize(int32(p.retrievalPageSize)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query underlying store: %w", err)
+	}
+
+	defer storage.Close(iterator, logger)
+
+	moreEntries, err := iterator.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	var encryptedDocuments []models.EncryptedDocument
+
+	for moreEntries {
+		mongoDBDocument, valueErr := iterator.ValueAsRawMap()
 		if valueErr != nil {
 			return nil, valueErr
+		}
+
+		encryptedDocumentBytes, err := json.Marshal(mongoDBDocument)
+		if err != nil {
+			return nil, err
 		}
 
 		var encryptedDocument models.EncryptedDocument
@@ -235,6 +270,10 @@ func (v *Vault) Query(query models.Query) ([]models.EncryptedDocument, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal encrypted document bytes: %w", err)
 		}
+
+		// This field is just for internal use - remove it before sending to client since it's not a proper field
+		// in an Encrypted Document.
+		encryptedDocument.VaultID = ""
 
 		encryptedDocuments = append(encryptedDocuments, encryptedDocument)
 
@@ -247,37 +286,10 @@ func (v *Vault) Query(query models.Query) ([]models.EncryptedDocument, error) {
 	return encryptedDocuments, nil
 }
 
-// StoreDataVaultConfiguration stores the given DataVaultConfiguration.
-func (v *Vault) StoreDataVaultConfiguration(config *models.DataVaultConfiguration) error {
-	mongoDBStore, ok := v.CoreStore.(*mongodb.Store)
-	if ok {
-		return mongoDBStore.PutAsJSON("DataVaultConfiguration", config)
-	}
+func createMongoDBIndex(mongoDBProvider *mongodb.Provider, documentDatabaseName string) error {
+	indexModels := generateMongoDBIndexModels()
 
-	configBytes, err := json.Marshal(config)
-	if err != nil {
-		return fmt.Errorf(messages.FailToMarshalConfig, err)
-	}
-
-	return v.CoreStore.Put("DataVaultConfiguration", configBytes)
-}
-
-// UUIDs based off vault IDs are used as store names since with the current implementation in the aries-framework-go
-// storage providers, stores are case-insensitive. There could be two vault IDs (in theory) that are identical except
-// for the case, so the UUID conversion should help avoid a conflict.
-// With some rework, this workaround could be removed.
-func (c *Provider) getUnderlyingStoreName(vaultID string) (string, error) {
-	err := c.checkIfBase58Encoded128BitValue(vaultID)
-	if err != nil {
-		return "", fmt.Errorf("invalid vault ID: %w", err)
-	}
-
-	convertedStoreName, err := c.base58Encoded128BitToUUID(vaultID)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate UUID from base 58 encoded 128 bit name: %w", err)
-	}
-
-	return convertedStoreName, nil
+	return mongoDBProvider.CreateCustomIndexes(documentDatabaseName, indexModels...)
 }
 
 func convertEDVQueryToAriesQuery(query models.Query) (string, error) {
@@ -298,122 +310,81 @@ func convertEDVQueryToAriesQuery(query models.Query) (string, error) {
 	return "", nil
 }
 
-func createMongoDBAttributeIndex(mongoDBProvider *mongodb.Provider, underlyingStoreName string) error {
-	model := generateMongoDBIndexModel()
-
-	err := mongoDBProvider.CreateCustomIndex(underlyingStoreName, model)
-	if err != nil {
-		return fmt.Errorf("failed to create index for indexed attributes: %w", err)
-	}
-
-	return nil
-}
-
-func generateMongoDBIndexModel() mongo.IndexModel {
-	model := mongo.IndexModel{
-		Keys: bson.D{
-			{Key: "indexed.attributes.name", Value: 1},
-			{Key: "indexed.attributes.value", Value: 1},
+func generateMongoDBIndexModels() []mongodriver.IndexModel {
+	model := []mongodriver.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: documentIDFieldName, Value: 1},
+				{Key: vaultIDTagName, Value: 1},
+			},
+			Options: mongooptions.Index().SetName("DocumentIDAndVaultID").SetUnique(true),
 		},
-		Options: mongooptions.Index().SetName("Indexed Attributes"),
+		{
+			Keys: bson.D{
+				{Key: "indexed.attributes.name", Value: 1},
+				{Key: "indexed.attributes.value", Value: 1},
+				{Key: vaultIDTagName, Value: 1},
+			},
+			Options: mongooptions.Index().SetName("AttributesAndVaultID"),
+		},
 	}
 
 	return model
 }
 
-func storeDocumentsForMongoDB(documents []models.EncryptedDocument, mongoDBStore *mongodb.Store) error {
-	operations := make([]mongodb.BatchAsJSONOperation, len(documents))
+func storeDocumentsForMongoDB(vaultID string, documents []models.EncryptedDocument, mongoDBStore *mongodb.Store) error {
+	writeModels := make([]mongodriver.WriteModel, len(documents))
 
 	for i := 0; i < len(documents); i++ {
-		operations[i].Key = documents[i].ID
-		// The document's ID will be used as the MongoDB document id (_id field).
+		documents[i].VaultID = vaultID
 
-		// To avoid having that data stored twice in the sample MongoDB document, we remove it from the
-		// Encrypted Document object. When everything gets marshalled and stored in MongoDB, the MongoDB document will
-		// look like an Encrypted Document but with the id field named _id instead.
+		mongoDBDocument, err := mongodb.PrepareDataForBSONStorage(documents[i])
+		if err != nil {
+			return err
+		}
 
-		documents[i].ID = "" // The model uses the omitempty JSON tag to ensure this field will disappear.
+		filter := bson.M{documentIDFieldName: documents[i].ID, vaultIDTagName: vaultID}
 
-		operations[i].Value = documents[i]
+		writeModels[i] = mongodriver.NewReplaceOneModel().SetFilter(filter).
+			SetReplacement(mongoDBDocument).SetUpsert(true)
 	}
 
-	return mongoDBStore.BatchAsJSON(operations)
+	return mongoDBStore.BulkWrite(writeModels)
 }
 
-func getFromMongoDB(mongoDBStore *mongodb.Store, id string) ([]byte, error) {
-	mongoDBDocument, err := mongoDBStore.GetAsRawMap(id)
+func (p *Provider) getFromMongoDB(store *mongodb.Store, vaultID, documentID string) ([]byte, error) {
+	filter := bson.D{
+		{Key: documentIDFieldName, Value: documentID},
+		{Key: vaultIDTagName, Value: vaultID},
+	}
+
+	documents, err := p.queryForEncryptedDocumentsFromMongoDB(store, filter)
 	if err != nil {
 		return nil, err
 	}
 
-	mongoDBDocument["id"] = mongoDBDocument["_id"]
+	if len(documents) == 0 {
+		return nil, storage.ErrDataNotFound
+	}
 
-	delete(mongoDBDocument, "_id")
-
-	encryptedDocumentBytes, err := json.Marshal(mongoDBDocument)
+	documentBytes, err := json.Marshal(documents[0])
 	if err != nil {
 		return nil, err
 	}
 
-	return encryptedDocumentBytes, nil
+	return documentBytes, nil
 }
 
-func (v *Vault) queryFromMongoDB(store *mongodb.Store, query models.Query) ([]models.EncryptedDocument, error) {
-	mongoDBQuery := convertEDVQueryToMongoDBQuery(query)
-
-	iterator, err := store.QueryCustom(mongoDBQuery, mongooptions.Find().SetBatchSize(int32(v.retrievalPageSize)))
-	if err != nil {
-		return nil, fmt.Errorf("failed to query underlying store: %w", err)
-	}
-
-	defer storage.Close(iterator, logger)
-
-	moreEntries, err := iterator.Next()
-	if err != nil {
-		return nil, err
-	}
-
-	var encryptedDocuments []models.EncryptedDocument
-
-	for moreEntries {
-		encryptedDocumentAsMongoDBDocument, valueErr := iterator.ValueAsRawMap()
-		if valueErr != nil {
-			return nil, valueErr
-		}
-
-		encryptedDocumentAsMongoDBDocument["id"] = encryptedDocumentAsMongoDBDocument["_id"]
-
-		delete(encryptedDocumentAsMongoDBDocument, "_id")
-
-		encryptedDocumentBytes, err := json.Marshal(encryptedDocumentAsMongoDBDocument)
-		if err != nil {
-			return nil, err
-		}
-
-		var encryptedDocument models.EncryptedDocument
-
-		err = json.Unmarshal(encryptedDocumentBytes, &encryptedDocument)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal encrypted document bytes: %w", err)
-		}
-
-		encryptedDocuments = append(encryptedDocuments, encryptedDocument)
-
-		moreEntries, err = iterator.Next()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return encryptedDocuments, nil
-}
-
-func convertEDVQueryToMongoDBQuery(edvQuery models.Query) bson.D {
+func convertEDVQueryToMongoDBQuery(vaultID string, edvQuery models.Query) bson.D {
 	if edvQuery.Has != "" {
 		return bson.D{
 			{
 				Key:   "indexed.attributes.name",
 				Value: edvQuery.Has,
+			},
+			{
+				Key:   vaultIDTagName,
+				Value: vaultID,
 			},
 		}
 	}
@@ -421,7 +392,14 @@ func convertEDVQueryToMongoDBQuery(edvQuery models.Query) bson.D {
 	mongoDBORQuery := make(bson.A, len(edvQuery.Equals))
 
 	mongoDBQuery := bson.D{
-		{Key: "$or", Value: mongoDBORQuery},
+		{
+			Key:   "$or",
+			Value: mongoDBORQuery,
+		},
+		{
+			Key:   vaultIDTagName,
+			Value: vaultID,
+		},
 	}
 
 	for i, subfilter := range edvQuery.Equals {
@@ -449,8 +427,14 @@ func convertEDVQueryToMongoDBQuery(edvQuery models.Query) bson.D {
 	return mongoDBQuery
 }
 
-func createTags(document models.EncryptedDocument) []storage.Tag {
-	var tags []storage.Tag
+func generateAriesDocumentEntryKey(vaultID, documentID string) string {
+	return fmt.Sprintf("%s-%s", vaultID, documentID)
+}
+
+func createTags(vaultID string, document *models.EncryptedDocument) []storage.Tag {
+	tags := []storage.Tag{
+		{Name: vaultIDTagName, Value: vaultID},
+	}
 
 	for _, indexedAttributeCollection := range document.IndexedAttributeCollections {
 		for _, indexedAttribute := range indexedAttributeCollection.IndexedAttributes {
@@ -464,27 +448,17 @@ func createTags(document models.EncryptedDocument) []storage.Tag {
 	return tags
 }
 
-// Adds tag names from tagNames2 that aren't in tagNames1 to tagNames1.
-// Duplicate tag names in tagNames2 are discarded.
-func mergeTagNames(tagNames1, tagNames2 []string) []string {
-	if len(tagNames1) == 0 {
-		return tagNames2
+func vaultIDTagMatches(targetVaultID string, queryResultsIterator storage.Iterator) (bool, error) {
+	tags, err := queryResultsIterator.Tags()
+	if err != nil {
+		return false, err
 	}
 
-	for i := 0; i < len(tagNames2); i++ {
-		var found bool
-
-		for j := 0; j < len(tagNames1); j++ {
-			if tagNames2[i] == tagNames1[j] {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			tagNames1 = append(tagNames1, tagNames2[i])
+	for _, tag := range tags {
+		if tag.Name == vaultIDTagName && tag.Value == targetVaultID {
+			return true, nil
 		}
 	}
 
-	return tagNames1
+	return false, nil
 }

--- a/pkg/edvutils/edvutils.go
+++ b/pkg/edvutils/edvutils.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/google/uuid"
 
 	"github.com/trustbloc/edv/pkg/restapi/messages"
 	"github.com/trustbloc/edv/pkg/restapi/models"
@@ -63,18 +62,6 @@ func CheckIfBase58Encoded128BitValue(id string) error {
 	}
 
 	return nil
-}
-
-// Base58Encoded128BitToUUID decodes the given string and creates a uuid from the bytes array.
-func Base58Encoded128BitToUUID(name string) (string, error) {
-	decodedBytes := base58.Decode(name)
-
-	storeNameUUID, err := uuid.FromBytes(decodedBytes)
-	if err != nil {
-		return "", err
-	}
-
-	return storeNameUUID.String(), nil
 }
 
 // CheckIfURI checks if the given string is a valid URI.

--- a/pkg/edvutils/edvutils_test.go
+++ b/pkg/edvutils/edvutils_test.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	testBase58encoded128bitString = "Sr7yHjomhn1aeaFnxREfRN"
-	testConvertedUUIDString       = "d15034fa-9525-4ebf-3352-d19c8b02cf05"
 
 	not128BitString = "testString"
 
@@ -88,19 +87,6 @@ func TestCheckIfBase58Encoded128BitValue(t *testing.T) {
 	t.Run("Failure - not 128 bit", func(t *testing.T) {
 		err := CheckIfBase58Encoded128BitValue(not128BitString)
 		require.Equal(t, messages.ErrNot128BitValue, err)
-	})
-}
-
-func TestBase58Encoded128BitToUUID(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		uuidString, err := Base58Encoded128BitToUUID(testBase58encoded128bitString)
-		require.NoError(t, err)
-		require.Equal(t, testConvertedUUIDString, uuidString)
-	})
-	t.Run("Failure - invalid UUID", func(t *testing.T) {
-		uuidString, err := Base58Encoded128BitToUUID("")
-		require.Empty(t, uuidString)
-		require.Error(t, err)
 	})
 }
 

--- a/pkg/restapi/controller_test.go
+++ b/pkg/restapi/controller_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestController_New(t *testing.T) {
 	controller, err := New(&operation.Config{
-		Provider: edvprovider.NewProvider(mem.NewProvider(), 10),
+		Provider: createEDVProvider(t),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, controller)
@@ -27,7 +27,7 @@ func TestController_New(t *testing.T) {
 
 func TestController_GetOperations(t *testing.T) {
 	controller, err := New(&operation.Config{
-		Provider:          edvprovider.NewProvider(mem.NewProvider(), 100),
+		Provider:          createEDVProvider(t),
 		EnabledExtensions: &operation.EnabledExtensions{ReadAllDocumentsEndpoint: true},
 	})
 	require.NoError(t, err)
@@ -66,4 +66,14 @@ func TestController_GetOperations(t *testing.T) {
 	require.Equal(t, "/encrypted-data-vaults/{vaultID}/documents/{docID}", ops[5].Path())
 	require.Equal(t, http.MethodDelete, ops[5].Method())
 	require.NotNil(t, ops[5].Handle())
+}
+
+func createEDVProvider(t *testing.T) *edvprovider.Provider {
+	t.Helper()
+
+	provider, err := edvprovider.NewProvider(mem.NewProvider(), "configurations",
+		"documents", 100)
+	require.NoError(t, err)
+
+	return provider
 }

--- a/pkg/restapi/models/models.go
+++ b/pkg/restapi/models/models.go
@@ -32,6 +32,8 @@ type EncryptedDocument struct {
 	Sequence                    uint64                       `json:"sequence,omitempty"`
 	IndexedAttributeCollections []IndexedAttributeCollection `json:"indexed,omitempty"`
 	JWE                         json.RawMessage              `json:"jwe,omitempty"`
+	// VaultID is just used internally for storing to MongoDB. It's always removed before returning data to a client.
+	VaultID string `json:"vaultID,omitempty"`
 }
 
 // IndexedAttributeCollection represents a collection of indexed attributes,

--- a/pkg/restapi/operation/respond.go
+++ b/pkg/restapi/operation/respond.go
@@ -211,7 +211,7 @@ func writeErrorWithVaultIDAndReceivedData(rw http.ResponseWriter, statusCode int
 }
 
 func writeErrorWithVaultIDAndDocID(rw http.ResponseWriter, statusCode int, message string, err error,
-	docID, vaultID string) {
+	vaultID, docID string) {
 	logger.Errorf(message, docID, vaultID, err)
 
 	rw.WriteHeader(statusCode)

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hyperledger/aries-framework-go v0.1.8
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220526205258-18d510d84955
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b
 	github.com/igor-pavlenko/httpsignatures-go v0.0.23
 	github.com/tidwall/gjson v1.6.7
 	github.com/trustbloc/edge-core v0.1.8

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -598,8 +598,8 @@ github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf/g
 github.com/hyperledger/aries-framework-go v0.1.8-0.20220217153004-1622c70e5767/go.mod h1:rBMOJVwyHyYbOqbb3IB/ExBkHyvFLht/W81s24GmjcE=
 github.com/hyperledger/aries-framework-go v0.1.8 h1:nKPGTqh+gYWrczJ7mf6clbnDegKPJg7TDis8SYNxcGo=
 github.com/hyperledger/aries-framework-go v0.1.8/go.mod h1:7ilurt17sjWruVIBxZSrwn8qUbROq8LXYYY+O7dNxIM=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220530120019-3080f681b76c h1:0HhZ3pvVu0t+kwnchfTF3mT6BArPgxPR0y3gO1Fmzsk=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220530120019-3080f681b76c/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf h1:F12zbOSRsye3IWK3Zb6prgrqQQFYnz5zjGSCh9pfYzk=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220615170242-cda5092b4faf/go.mod h1:GDANCnJONcCqBvv6QgKuk5Y2FWHyD/Hu26kyc7NTyfY=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:7D+Y5J9cIsUrMGFAsIED+3bAPNjxp6ggXo0/kT5N6BI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210820175050-dcc7a225178d/go.mod h1:i40JkMHCh9cHHxSc1SYznO3xDH6ly5CE0B3vPYZVeWI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20220322085443-50e8f9bd208b/go.mod h1:eIac5lubCy3tw6D0sTluM5U6Bw3inBwUfjX17o2U7PE=
@@ -632,8 +632,8 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20220217153004-1622c70e5767
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220322085443-50e8f9bd208b/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220324201531-18c87667df19/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330140627-07042d78580c/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955 h1:80KPbv4fo0NBmFV6KCrevQSX9yezkBnz5v5yuEpcrAg=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b h1:wSUDDrB87VuaxOmyb0CmA3wB8vvgZ3p9Te4Dnsi6NXs=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220614152730-3d817acfa48b/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:asiCVCtH/nocWKhZRMz12aFgdUh8lRHqKis0M8Ei/4I=
@@ -691,8 +691,8 @@ github.com/klauspost/compress v1.10.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.5 h1:qyCLMz2JCrKADihKOh9FxnW3houKeNsp2h5OEz0QSEA=
-github.com/klauspost/compress v1.15.5/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.6 h1:6D9PcO8QWu0JyaQ2zUMmu16T1T+zjjEpP91guRsvDfY=
+github.com/klauspost/compress v1.15.6/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -1224,8 +1224,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
-golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Previously, a new database/collection was created for every vault. This could cause issues when there are many vaults as the number of databases can start to become unmanageable. This change uses a single database for all documents.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>