### PR TITLE
feat: Allow GNAP and ZCAP authorization to work at the same time

### DIFF
--- a/cmd/edv-rest/startcmd/start_test.go
+++ b/cmd/edv-rest/startcmd/start_test.go
@@ -373,22 +373,6 @@ func TestCreateProvider(t *testing.T) {
 }
 
 func TestHttpHandler_ServeHTTP(t *testing.T) {
-	t.Run("test create vault request", func(t *testing.T) {
-		m := &mockHTTPHandler{serveHTTPFun: func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, r.RequestURI, createVaultPath)
-		}}
-		h := zcapAuthHandler{routerHandler: m, authZCAPSvc: &mockAuthService{}}
-		h.ServeHTTP(&httptest.ResponseRecorder{}, &http.Request{RequestURI: createVaultPath})
-	})
-
-	t.Run("test health check request", func(t *testing.T) {
-		m := &mockHTTPHandler{serveHTTPFun: func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, r.RequestURI, healthCheckPath)
-		}}
-		h := zcapAuthHandler{routerHandler: m, authZCAPSvc: &mockAuthService{}}
-		h.ServeHTTP(&httptest.ResponseRecorder{}, &http.Request{RequestURI: healthCheckPath})
-	})
-
 	t.Run("test error from auth handler", func(t *testing.T) {
 		h := zcapAuthHandler{authZCAPSvc: &mockAuthService{
 			handlerFunc: func(resourceID string, req *http.Request, w http.ResponseWriter,
@@ -420,14 +404,6 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("test GNAP auth handler", func(t *testing.T) {
-		t.Run("Request URI is health check path, so auth check is skipped", func(t *testing.T) {
-			h := gnapAuthHandler{routerHandler: &mockHTTPHandler{}}
-
-			responseRecorder := httptest.NewRecorder()
-			h.ServeHTTP(responseRecorder, &http.Request{RequestURI: healthCheckPath})
-
-			require.Equal(t, http.StatusOK, responseRecorder.Code)
-		})
 		t.Run("Missing token header", func(t *testing.T) {
 			h := gnapAuthHandler{}
 

--- a/docs/rest/edv_cli.md
+++ b/docs/rest/edv_cli.md
@@ -14,8 +14,8 @@ Parameters can be set by command line arguments or environment variables:
 
 ```      
 Flags:
-      --auth-server-url                    string                    The URL of Auth server. Required if using GNAP authorization. Alternatively, this can be set with the following environment variable: EDV_AUTH_SERVER_URL
-      --auth-type                          string                          The type of authorization to use. Possible values [none] [GNAP] [ZCAP]. Defaults to none if not set. Alternatively, this can be set with the following environment variable: EDV_AUTH_TYPE
+      --auth-server-url                    string                    The URL of the authorization server. Required if using GNAP authorization. Ignored otherwise. Alternatively, this can be set with the following environment variable: EDV_AUTH_SERVER_URL
+      --auth-type                          string                          Comma-separated list of the types of authorization to enable. Authorization is server-wide, not per-vault. Possible values [GNAP] [ZCAP]. If GNAP and ZCAP are both enabled, then a client may authorize themselves with either one (rather than the two stacking on top of each other). If no options are specified, then no authorization will be required. Alternatively, this can be set with the following environment variable: EDV_AUTH_TYPE
   -c, --config-database-name               string               The name of the main database where data vault configurations will be stored. Defaults to "configurations" if not set Alternatively, this can be set with the following environment variable: EDV_DOCUMENT_DATABASE_NAME
       --cors-enable                        string                        Enable cors. Possible values [true] [false]. Defaults to false if not set. Alternatively, this can be set with the following environment variable: EDV_CORS_ENABLE
   -p, --database-prefix                    string                    An optional prefix to be used for the names for all databases. Alternatively, this can be set with the following environment variable: EDV_DATABASE_PREFIX
@@ -25,7 +25,7 @@ Flags:
   -r, --database-url                       string                       The URL (or connection string) of the database. Not needed if using memstore. For CouchDB, include the username:password@ text if required. Alternatively, this can be set with the following environment variable: EDV_DATABASE_URL
       --did-domain                         string                         URL to the did consortium's domain. Alternatively, this can be set with the following environment variable: EDV_DID_DOMAIN
   -d, --document-database-name             string             The name of the database where encrypted documents will be stored. Defaults to "documents" if not set Alternatively, this can be set with the following environment variable: EDV_DOCUMENT_DATABASE_NAME
-      --gnap-signing-key                   string                   The path to the private key to use when signing GNAP introspection requests. Alternatively, this can be set with the following environment variable: EDV_GNAP_SIGNING_KEY
+      --gnap-signing-key                   string                   The path to the private key to use when signing GNAP introspection requests. Required if using GNAP authorization. Ignored otherwise. Alternatively, this can be set with the following environment variable: EDV_GNAP_SIGNING_KEY
   -h, --help                                      help for start
   -u, --host-url                           string                           URL to run the edv instance on. Format: HostName:Port. Alternatively, this can be set with the following environment variable: EDV_HOST_URL
       --localkms-secrets-database-prefix   string   An optional prefix to be used when creating and retrieving the underlying KMS secrets database. Alternatively, this can be set with the following environment variable: EDV_LOCALKMS_SECRETS_DATABASE_PREFIX

--- a/scripts/check_integration.sh
+++ b/scripts/check_integration.sh
@@ -11,14 +11,21 @@ cd test/bdd
 
 # TODO (#220): Reduce BDD test running time by only starting storage containers as needed.
 
-echo "Running EDV integration tests using MongoDB + GNAP authorization..."
+echo "Running EDV integration tests using MongoDB + GNAP or ZCAP authorization..."
+
+export EDV_DATABASE_TYPE=mongodb
+export EDV_DATABASE_URL=mongodb://mongodb.example.com:27017
+export EDV_AUTH_TYPE=GNAP,ZCAP
+go test -count=1 -v -cover . -p 1 -timeout=20m -race
+
+echo "Running EDV integration tests using MongoDB + GNAP only authorization..."
 
 export EDV_DATABASE_TYPE=mongodb
 export EDV_DATABASE_URL=mongodb://mongodb.example.com:27017
 export EDV_AUTH_TYPE=GNAP
 go test -count=1 -v -cover . -p 1 -timeout=20m -race
 
-echo "Running EDV integration tests using MongoDB + ZCAP authorization..."
+echo "Running EDV integration tests using MongoDB + ZCAP only authorization..."
 
 export EDV_DATABASE_TYPE=mongodb
 export EDV_DATABASE_URL=mongodb://mongodb.example.com:27017
@@ -29,7 +36,7 @@ echo "Running EDV integration tests using MongoDB + no authorization..."
 
 export EDV_DATABASE_TYPE=mongodb
 export EDV_DATABASE_URL=mongodb://mongodb.example.com:27017
-export EDV_AUTH_TYPE=none
+export EDV_AUTH_TYPE=
 go test -count=1 -v -cover . -p 1 -timeout=20m -race
 
 echo "Running EDV integration tests using CouchDB + GNAP authorization..."

--- a/test/bdd/pkg/context/context.go
+++ b/test/bdd/pkg/context/context.go
@@ -329,7 +329,9 @@ func createProxyEDVClient(ctx *BDDContext) (*edvclient.Client, error) {
 		})
 
 		options = append(options, withHeadersOpt)
-	} else if strings.EqualFold(authType, "gnap") {
+	} else if strings.EqualFold(authType, "gnap") || strings.EqualFold(authType, "GNAP,ZCAP") {
+		println("Adding header function to EDV client for GNAP...")
+
 		option, err := addGNAPHeaderOption(&tlsConfig)
 		if err != nil {
 			return nil, err
@@ -645,7 +647,9 @@ func createTrustBlocEDVClient(ctx *BDDInteropContext) (*edvclient.Client, error)
 		})
 
 		options = append(options, withHeadersOpt)
-	} else if strings.EqualFold(authType, "gnap") {
+	} else if strings.EqualFold(authType, "gnap") || strings.EqualFold(authType, "GNAP,ZCAP") {
+		println("Adding header function to EDV client for GNAP...")
+
 		option, err := addGNAPHeaderOption(&tlsConfig)
 		if err != nil {
 			return nil, err

--- a/test/bdd/pkg/edv/edv_steps.go
+++ b/test/bdd/pkg/edv/edv_steps.go
@@ -147,6 +147,8 @@ func (e *Steps) createDataVault() error { //nolint:funlen // test file
 	e.bddContext.VaultID = vaultID
 
 	if strings.EqualFold(authType, "zcap") {
+		println(fmt.Sprintf("Received the following ZCAP payload: %s", string(resp)))
+
 		capability, err := zcapld.ParseCapability(resp)
 		if err != nil {
 			return err


### PR DESCRIPTION
Now GNAP and ZCAP authorization can run at the same time. The way this implementation works is that if the server has both mechanisms active, then a client may choose to authorize themselves with either one, (rather than the two stacking on top of each other).

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>