### PR TITLE
fix: Docker warning and update spec links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,12 @@ run-openapi-demo: generate-openapi-demo-specs
 	@FIXTURES_PATH=test/bdd/fixtures  \
         scripts/run-openapi-demo.sh
 
+# TODO (#264): frapsoft/openssl only has an amd64 version. While this does work under amd64 and arm64 Mac OS currently,
+#               we should add an arm64 version for systems that can only run arm64 code.
 .PHONY: generate-test-keys
 generate-test-keys:
 	@mkdir -p test/bdd/fixtures/keys/tls
-	@docker run -i --rm \
+	@docker run -i --platform linux/amd64 --rm \
 		-v $(abspath .):/opt/workspace/edv \
 		--entrypoint "/opt/workspace/edv/scripts/generate_test_keys.sh" \
 		frapsoft/openssl

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/trustbloc/edv)](https://goreportcard.com/report/github.com/trustbloc/edv)
 
 # edv
-An implementation of Encrypted Data Vaults [from the Confidential Storage 0.1 (04 December 2020) specification](https://identity.foundation/confidential-storage/). This implementation is a work in progress; be sure to read the [limitations](#limitations) section which outlines which parts of the specification have yet to be implemented.
+An implementation of the [Encrypted Data Vaults v0.1 (20 June 2022) specification](https://identity.foundation/edv-spec/). This implementation is a work in progress; be sure to read the [limitations](#limitations) section which outlines which parts of the specification have yet to be implemented.
 
 ## Limitations
 The following has not yet been implemented:
 * Service endpoint discovery
 * Encrypted attribute querying with multiple name+value pairs
 * Support for the unique property on an encrypted attribute pair
-* Streams (also a work in-progress in the [specification](https://identity.foundation/confidential-storage/))
+* Streams (also a work in-progress in the [specification](https://identity.foundation/edv-spec/))
 
 ## Underlying Storage
 This EDV server is not by itself a database - a database provider must be chosen for it to work. This underlying database is used by the EDV server for storage of encrypted data. Currently, three database providers are supported:


### PR DESCRIPTION
* Resolved a warning from Docker that would get printed when running the generate-test-keys Makefile target on an arm64 system. The warning from Docker alerts you that the image for frapsoft/openssl is for amd64, which doesn't match the system you're on (when using an arm64-based OS). To resolve the warning, you have to either use an image that matches the system architecture, or explicitly state the platform using the --platform flag. In this case, there is only an amd64 version of frapsoft/openssl, so I added the explicit flag to resolve the warning. I also added a TODO for us to find an arm64 alternative in the future (although the amd64 version of frapsoft/openssl does seem to work fine on arm64 Mac OS currently, presumably due to Apple's Rosetta translation layer or some other emulation layer).
* Updated spec links to point to the current, most up-to-date spec.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>