### PR TITLE
chore(deps): bump auth to 0.1.9-snapshot-4b6c339

### DIFF
--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -72,9 +72,8 @@ func runBDDTests(tags, format string) int { //nolint: gocognit
 				}
 
 				sleepAndWait(testSleep)
-
-				FeatureContext(s)
 			}
+			FeatureContext(s)
 		})
 		s.AfterSuite(func() {
 			for _, c := range composition {

--- a/test/bdd/fixtures/edv-rest/.env
+++ b/test/bdd/fixtures/edv-rest/.env
@@ -26,7 +26,7 @@ COUCHDB_USERNAME=admin
 COUCHDB_PASSWORD=password
 
 AUTH_REST_IMAGE=ghcr.io/trustbloc-cicd/auth
-AUTH_REST_IMAGE_TAG=0.1.9-snapshot-2540de8
+AUTH_REST_IMAGE_TAG=0.1.9-snapshot-4b6c339
 
 HYDRA_IMAGE_TAG=v1.3.2-alpine
 MYSQL_IMAGE_TAG=8.0.20


### PR DESCRIPTION
Signed-off-by: Yevgen Pukhta <eugene.pukhta@gmail.com>

Changes:
- pump auth to the latest (https://github.com/orgs/trustbloc-cicd/packages/container/auth/42687299?tag=0.1.9-snapshot-4b6c339)
- fix edv bdd tests to work with the latest auth
- fix for `DISABLE_COMPOSITION` mode. BDD context was not initialized when the flag had been set.  